### PR TITLE
don't block forever if wintun isn't installed

### DIFF
--- a/service/ziti-tunnel/service/service.go
+++ b/service/ziti-tunnel/service/service.go
@@ -40,6 +40,7 @@ func (m *zitiService) Execute(args []string, r <-chan svc.ChangeRequest, changes
 			log.Errorf("the main loop exited with an unexpected error: %v", err)
 		}
 		mainLoop <- struct{}{}
+		control <- "shutting down"
 	}()
 loop:
 	for {


### PR DESCRIPTION
if the driver wasn't installed a channel would sit blocked forever - this fixes that