### PR TITLE
Add orphaned identities back + bugfix

### DIFF
--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -287,7 +287,7 @@ namespace ZitiDesktopEdge {
 
 		async private void StartZitiService(object sender, RoutedEventArgs e) {
 			try {
-				ShowLoad("Starting", "Staring the data service");
+				ShowLoad("Starting", "Starting the data service");
 				logger.Info("StartZitiService");
 				var r = await monitorClient.StartServiceAsync();
 				if (r.Code != 0) {


### PR DESCRIPTION
closes #243 - startup failure assigning TUN mask to 0 and blocking all traffic
closes #242 - add orphaned identities back to UI/service