### PR TITLE
fix identities off by default when service restarts

### DIFF
--- a/Installer/collect-logs.ps1
+++ b/Installer/collect-logs.ps1
@@ -43,6 +43,7 @@ cp $logsrc $logdest
 
 echo " "
 echo "    creating archive: ${destArchive}"
+mkdir "${logroot}\UI" -ErrorAction SilentlyContinue
 compress-archive -Path "${ipinfo}","${logroot}\ziti-service","${logroot}\UI","${logroot}\ZitiMonitorService" -DestinationPath "${destArchive}"
 
 echo " "


### PR DESCRIPTION
1.5.9 introduced a bug where identities are 'off' by default when starting the service back up. this will fix that

closes #245 