### PR TITLE
better logging - fix server 2016 crash

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,16 @@
+# Ziti Desktop Edge for Windows
+
+(the uwp project which used to be here has moved to [uwp-vpnplugin-archive](.uwp-vpnplugin-archive) and is likely abandoned)
+
+The Ziti Desktop Edge for Windows is an application that is necessary to integrate applications which cannot embed a Ziti SDK
+directly into the application. This is colloquially known as a "brown field" Ziti-enabled application because the app
+itself has no understanding that it has been Ziti-enabled.
+
+In order for an application that has no knowledge of being Ziti-enabled to work the connections established by the app
+must be intercepted before leaving the computer and routed through the Ziti network. This is accomplished by three main
+components:
+
+* [wintun](https://www.wintun.net) - provides a Layer 3 TUN for Windows
+* A Windows service which runs as the local system account which creates the TUN as well as manages the Ziti connections
+* A Windows UWP UI application that allows the interactively logged on user to interact with the Windows service
+

--- a/service/build.bat
+++ b/service/build.bat
@@ -14,7 +14,7 @@ REM See the License for the specific language governing permissions and
 REM limitations under the License.
 REM
 SET REPO_URL=https://github.com/openziti/ziti-tunnel-sdk-c.git
-SET ZITI_TUNNEL_REPO_BRANCH=v0.7.22
+SET ZITI_TUNNEL_REPO_BRANCH=v0.7.24
 REM override the c sdk used in the build - leave blank for the same as specified in the tunneler sdk
 SET ZITI_SDK_C_BRANCH=
 REM the number of TCP connections the tunneler sdk can have at any one time

--- a/service/cziti/sdk.c
+++ b/service/cziti/sdk.c
@@ -28,7 +28,7 @@ void set_log_level(int level, libuv_ctx *lctx) {
 }
 
 void log_writer_shim_go(int level, const char *loc, const char *msg, size_t msglen) {
-  log_writer_cb(level, (char*)loc, (char*)msg, msglen);
+  log_writer_cb(level, (char*)loc, (char*)msg, (int)msglen);
 }
 
 void libuv_init(libuv_ctx *lctx) {
@@ -38,11 +38,8 @@ void libuv_init(libuv_ctx *lctx) {
 }
 
 void libuv_runner(void *arg) {
-    ZITI_LOG(INFO, "starting event loop");
     uv_loop_t *l = arg;
     uv_run(l, UV_RUN_DEFAULT);
-
-    ZITI_LOG(INFO, "event finished finished\n");
 }
 
 void libuv_run(libuv_ctx *lctx) {
@@ -76,10 +73,6 @@ extern void c_mapiter(model_map *map) {
 		printf("k: %s, v: %s", k, v);
 		it = model_map_it_next(it);
 	}
-}
-
-void ZLOG(int level, char* msg) {
-    ZITI_LOG(level, "%s", msg);
 }
 
 bool is_null(void* anything){

--- a/service/cziti/sdk.go
+++ b/service/cziti/sdk.go
@@ -22,6 +22,7 @@ package cziti
 
 #include <ziti/ziti.h>
 #include "ziti/ziti_tunnel.h"
+#include "ziti/ziti_log.h"
 
 #include "sdk.h"
 extern void initCB(ziti_context nf, int status, void *ctx);
@@ -369,8 +370,8 @@ func free_async(handle *C.uv_handle_t){
 }
 
 //export log_writer_cb
-func log_writer_cb(level C.int, loc C.string, msg C.string, _ /*msglen*/ C.size_t) {
-	gomsg := C.GoString(msg)
+func log_writer_cb(level C.int, loc C.string, msg C.string, msglen C.int) {
+	gomsg := C.GoStringN(msg, msglen)
 	goline := C.GoString(loc)
 	lvl := level
 	switch lvl {

--- a/service/cziti/sdk.h
+++ b/service/cziti/sdk.h
@@ -16,6 +16,7 @@
  */
 #ifndef GOLANG_SDK_H
 #define GOLANG_SDK_H
+
 #include <stdio.h>
 #include <stdlib.h>
 #define USING_ZITI_SHARED
@@ -56,6 +57,6 @@ extern void ziti_pq_mac_go(ziti_context ztx, char *id, ziti_pr_mac_cb response_c
 //logging callback
 extern void log_writer_shim_go(int level, const char *loc, const char *msg, size_t msglen);
 
-void log_writer_cb(int level, char *loc, char *msg, size_t msglen);
+void log_writer_cb(int level, char *loc, char *msg, int msglen);
 bool is_null(void* anything);
 #endif /* GOLANG_SDK_H */


### PR DESCRIPTION
* closes #266 by using a newer library with proper MINGW flags set
* update logging to use the size of the line passed in callback
