### PR TITLE
capture netstat, route, running tasks and change close handling of th…

### DIFF
--- a/ZitiUpdateService/UpdateService.cs
+++ b/ZitiUpdateService/UpdateService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.ServiceProcess;
@@ -189,6 +189,9 @@ namespace ZitiUpdateService {
 				outputSystemInfo(destinationLocation);
 				outputDnsCache(destinationLocation);
 				outputExternalIP(destinationLocation);
+				outputTasklist(destinationLocation);
+				outputRouteInfo(destinationLocation);
+				outputNetstatInfo(destinationLocation);
 
 				Task.Delay(500).Wait();
 
@@ -216,7 +219,7 @@ namespace ZitiUpdateService {
 				startInfo.WindowStyle = ProcessWindowStyle.Hidden;
 				startInfo.FileName = "cmd.exe";
 				var ipconfigOut = Path.Combine(destinationFolder, "ipconfig.all.txt");
-				Logger.Info("copying ipconfig /all to {0}", ipconfigOut);
+				Logger.Debug("copying ipconfig /all to {0}", ipconfigOut);
 				startInfo.Arguments = $"/C ipconfig /all > \"{ipconfigOut}\"";
 				process.StartInfo = startInfo;
 				process.Start();
@@ -234,7 +237,7 @@ namespace ZitiUpdateService {
 				startInfo.WindowStyle = ProcessWindowStyle.Hidden;
 				startInfo.FileName = "cmd.exe";
 				var sysinfoOut = Path.Combine(destinationFolder, "systeminfo.txt");
-				Logger.Info("running systeminfo to {0}", sysinfoOut);
+				Logger.Debug("running systeminfo to {0}", sysinfoOut);
 				startInfo.Arguments = $"/C systeminfo > \"{sysinfoOut}\"";
 				process.StartInfo = startInfo;
 				process.Start();
@@ -252,7 +255,7 @@ namespace ZitiUpdateService {
 				startInfo.WindowStyle = ProcessWindowStyle.Hidden;
 				startInfo.FileName = "cmd.exe";
 				var dnsCache = Path.Combine(destinationFolder, "dnsCache.txt");
-				Logger.Info("running ipconfig /displaydns to {0}", dnsCache);
+				Logger.Debug("running ipconfig /displaydns to {0}", dnsCache);
 				startInfo.Arguments = $"/C ipconfig /displaydns > \"{dnsCache}\"";
 				process.StartInfo = startInfo;
 				process.Start();
@@ -271,6 +274,60 @@ namespace ZitiUpdateService {
 				resp.EnsureSuccessStatusCode();
 				string responseBody = resp.Content.ReadAsStringAsync().Result;
 				File.WriteAllText(extIpFile, responseBody);
+			} catch (Exception ex) {
+				Logger.Error(ex, "Unexpected error {0}", ex.Message);
+			}
+		}
+
+		private void outputTasklist(string destinationFolder) {
+			Logger.Info("capturing executing tasks");
+			try {
+				Process process = new Process();
+				ProcessStartInfo startInfo = new ProcessStartInfo();
+				startInfo.WindowStyle = ProcessWindowStyle.Hidden;
+				startInfo.FileName = "cmd.exe";
+				var tasklistOutput = Path.Combine(destinationFolder, "tasklist.txt");
+				Logger.Debug("running tasklist to {0}", tasklistOutput);
+				startInfo.Arguments = $"/C tasklist > \"{tasklistOutput}\"";
+				process.StartInfo = startInfo;
+				process.Start();
+				process.WaitForExit();
+			} catch (Exception ex) {
+				Logger.Error(ex, "Unexpected error {0}", ex.Message);
+			}
+		}
+
+		private void outputRouteInfo(string destinationFolder) {
+			Logger.Info("capturing network routes");
+			try {
+				Process process = new Process();
+				ProcessStartInfo startInfo = new ProcessStartInfo();
+				startInfo.WindowStyle = ProcessWindowStyle.Hidden;
+				startInfo.FileName = "cmd.exe";
+				var networkRoutes = Path.Combine(destinationFolder, "network-routes.txt");
+				Logger.Debug("running route print to {0}", networkRoutes);
+				startInfo.Arguments = $"/C route print > \"{networkRoutes}\"";
+				process.StartInfo = startInfo;
+				process.Start();
+				process.WaitForExit();
+			} catch (Exception ex) {
+				Logger.Error(ex, "Unexpected error {0}", ex.Message);
+			}
+		}
+
+		private void outputNetstatInfo(string destinationFolder) {
+			Logger.Info("capturing netstat");
+			try {
+				Process process = new Process();
+				ProcessStartInfo startInfo = new ProcessStartInfo();
+				startInfo.WindowStyle = ProcessWindowStyle.Hidden;
+				startInfo.FileName = "cmd.exe";
+				var netstatOutput = Path.Combine(destinationFolder, "netstat.txt");
+				Logger.Debug("running netstat -ano to {0}", netstatOutput);
+				startInfo.Arguments = $"/C netstat -ano > \"{netstatOutput}\"";
+				process.StartInfo = startInfo;
+				process.Start();
+				process.WaitForExit();
 			} catch (Exception ex) {
 				Logger.Error(ex, "Unexpected error {0}", ex.Message);
 			}

--- a/service/build.bat
+++ b/service/build.bat
@@ -14,7 +14,7 @@ REM See the License for the specific language governing permissions and
 REM limitations under the License.
 REM
 SET REPO_URL=https://github.com/openziti/ziti-tunnel-sdk-c.git
-SET ZITI_TUNNEL_REPO_BRANCH=v0.8.3
+SET ZITI_TUNNEL_REPO_BRANCH=v0.8.5
 REM override the c sdk used in the build - leave blank for the same as specified in the tunneler sdk
 SET ZITI_SDK_C_BRANCH=
 REM the number of TCP connections the tunneler sdk can have at any one time

--- a/service/ziti-tunnel/service/state.go
+++ b/service/ziti-tunnel/service/state.go
@@ -430,19 +430,33 @@ func (t *RuntimeState) RemoveRoute(destination net.IPNet, nextHop net.IP) error 
 	return luid.DeleteRoute(destination, nextHop)
 }
 
-
 func (t *RuntimeState) Close() {
 	if t.tun != nil {
 		tu := *t.tun
 		err := tu.Close()
 		if err != nil {
-			log.Fatalf("problem closing tunnel!")
+			log.Error("problem closing tunnel!")
 		}
 	} else {
 		log.Warn("unexpected situation. the TUN was null? ")
 	}
+	t.RemoveZitiTun()
 }
 
+func(t *RuntimeState) RemoveZitiTun() {
+	log.Infof("Removing existing interface: %s", TunName)
+	wt, err := tun.WintunPool.OpenAdapter(TunName)
+	if err == nil {
+		// If so, we delete it, in case it has weird residual configuration.
+		_, err = wt.Delete(true)
+		if err != nil {
+			log.Errorf("Error deleting already existing interface: %v", err)
+		}
+	} else {
+		log.Tracef("INTERFACE %s was nil? must have been removed already. %v", TunName, err)
+	}
+	log.Infof("Successfully removed interface: %s", TunName)
+}
 
 func (t *RuntimeState) InterceptDNS() {
 	log.Panicf("implement me")


### PR DESCRIPTION
same exact pr as before... seems liek a GH bug... https://github.com/openziti/desktop-edge-win/pull/300

Update to the latest tunneler sdk/c sdk combo
for any reason when exiting the main loop of the service - ensure the tun is closed
add three new diagnostic collections: netstat, tasklist, routes