### PR TITLE
Tun write eof check

### DIFF
--- a/service/cziti/ctun.go
+++ b/service/cziti/ctun.go
@@ -232,6 +232,10 @@ func (t *tunnel) runWriteLoop() {
 
 			n, err := t.dev.Write(p, 0)
 			if err != nil {
+				if err == io.EOF || err == os.ErrClosed {
+					//that's fine...
+					return
+				}
 				log.Panicf("An unexpected and unrecoverable error has occurred while %s: %v", "writing to tun device", err)
 			}
 

--- a/service/ziti-tunnel/service/ipc.go
+++ b/service/ziti-tunnel/service/ipc.go
@@ -35,7 +35,6 @@ import (
 	idcfg "github.com/openziti/sdk-golang/ziti/config"
 	"github.com/openziti/sdk-golang/ziti/enroll"
 	"golang.org/x/sys/windows/svc"
-	"golang.zx2c4.com/wireguard/tun"
 	"io"
 	"io/ioutil"
 	"math"
@@ -189,18 +188,7 @@ func SubMain(ops chan string, changes chan<- svc.Status, winEvents <-chan Window
 	log.Infof("shutting down events...")
 	events.shutdown()
 
-	log.Infof("Removing existing interface: %s", TunName)
-	wt, err := tun.WintunPool.OpenAdapter(TunName)
-	if err == nil {
-		// If so, we delete it, in case it has weird residual configuration.
-		_, err = wt.Delete(true)
-		if err != nil {
-			log.Errorf("Error deleting already existing interface: %v", err)
-		}
-	} else {
-		log.Errorf("INTERFACE %s was nil? %v", TunName, err)
-	}
-
+	log.Infof("Closing connections and removing tun interface: %s", TunName)
 	rts.Close()
 
 	log.Info("==============================  service ends  ==============================")

--- a/service/ziti-tunnel/service/state.go
+++ b/service/ziti-tunnel/service/state.go
@@ -499,9 +499,13 @@ func (t *RuntimeState) RemoveRoute(destination net.IPNet, nextHop net.IP) error 
 func (t *RuntimeState) Close() {
 	if t.tun != nil {
 		tu := *t.tun
+		log.Infof("Closing native tun: %s", TunName)
 		err := tu.Close()
+
 		if err != nil {
 			log.Error("problem closing tunnel!")
+		} else {
+			log.Infof("Closed native tun: %s", TunName)
 		}
 	} else {
 		log.Warn("unexpected situation. the TUN was null? ")
@@ -517,6 +521,8 @@ func (t *RuntimeState) RemoveZitiTun() {
 		_, err = wt.Delete(true)
 		if err != nil {
 			log.Errorf("Error deleting already existing interface: %v", err)
+		} else {
+			log.Infof("Removed wintun tun: %s", TunName)
 		}
 	} else {
 		log.Tracef("INTERFACE %s was nil? must have been removed already. %v", TunName, err)


### PR DESCRIPTION
There was a panic error while closing the tun interface, because the read loop exits when it receives the "file already closed" error, but the write loop does not exit gracefully. This is a race condition which occurs very rarely during the shutdown of the tunnel interface. So we need to handle the file closed error in the write loop as well. (These errors have been spotted in the logs of 3 of our NF employees and it happens very rarely)

Error message : An unexpected and unrecoverable error has occurred while writing to tun device: file already closed

Occasionally we see the tunnel hanging at the native tun close/remove function. This too is a rare scenario. So we added more logging to verify exactly where it is hanging. Redundant delete tun calls are removed