### PR TITLE
assigning nil after successful closing

### DIFF
--- a/service/ziti-tunnel/service/ipc.go
+++ b/service/ziti-tunnel/service/ipc.go
@@ -189,6 +189,9 @@ func SubMain(ops chan string, changes chan<- svc.Status, winEvents <-chan Window
 	log.Infof("shutting down events...")
 	events.shutdown()
 
+	log.Infof("Closing connections and removing tun interface: %s", TunName)
+	rts.Close()
+
 	log.Info("==============================  service ends  ==============================")
 
 	ops <- "done"

--- a/service/ziti-tunnel/service/ipc.go
+++ b/service/ziti-tunnel/service/ipc.go
@@ -189,9 +189,6 @@ func SubMain(ops chan string, changes chan<- svc.Status, winEvents <-chan Window
 	log.Infof("shutting down events...")
 	events.shutdown()
 
-	log.Infof("Closing connections and removing tun interface: %s", TunName)
-	rts.Close()
-
 	log.Info("==============================  service ends  ==============================")
 
 	ops <- "done"

--- a/service/ziti-tunnel/service/state.go
+++ b/service/ziti-tunnel/service/state.go
@@ -505,6 +505,7 @@ func (t *RuntimeState) Close() {
 		if err != nil {
 			log.Error("problem closing tunnel!")
 		} else {
+			t.tun = nil
 			log.Infof("Closed native tun: %s", TunName)
 		}
 	} else {

--- a/service/ziti-tunnel/service/state.go
+++ b/service/ziti-tunnel/service/state.go
@@ -40,8 +40,14 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 )
+
+var tun_release atomic.Value
+var running = "running"
+var success = "success"
+var failed = "failed"
 
 type RuntimeState struct {
 	state   *dto.TunnelStatus
@@ -497,6 +503,17 @@ func (t *RuntimeState) RemoveRoute(destination net.IPNet, nextHop net.IP) error 
 }
 
 func (t *RuntimeState) Close() {
+	val := tun_release.Load()
+	if val != nil {
+		if val == running {
+			log.Debugf("Tun is already closing!")
+			return
+		} else if val == success {
+			log.Debugf("Tun is already closed!")
+			return
+		}
+	}
+	tun_release.Store(running)
 	if t.tun != nil {
 		tu := *t.tun
 		log.Infof("Closing native tun: %s", TunName)
@@ -506,12 +523,16 @@ func (t *RuntimeState) Close() {
 			log.Error("problem closing tunnel!")
 		} else {
 			t.tun = nil
+			tun_release.Store(success)
 			log.Infof("Closed native tun: %s", TunName)
 		}
 	} else {
 		log.Warn("unexpected situation. the TUN was null? ")
 	}
 	t.RemoveZitiTun()
+	if tun_release.Load() == running {
+		tun_release.Store(failed)
+	}
 }
 
 func (t *RuntimeState) RemoveZitiTun() {
@@ -523,6 +544,7 @@ func (t *RuntimeState) RemoveZitiTun() {
 		if err != nil {
 			log.Errorf("Error deleting already existing interface: %v", err)
 		} else {
+			tun_release.Store(success)
 			log.Infof("Removed wintun tun: %s", TunName)
 		}
 	} else {


### PR DESCRIPTION
closing the tun twice causes nil error. Removing one function call rts.close() after shutdown will cause the program to exit soon before defer rts.close is finished. So, A=assigned nil after closing the tun