### PR TITLE
update to newest tsdk to fix mfa issue

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,7 +1,9 @@
 # Release 2.1.5
 
 ## What's New
-* DNS server IP has changed! If you expect the DNS server to be at 100.64.0.3 (or IP + 2) it will now be IP + 1.
+* DNS server IP has changed!!! If you expect the DNS server to be at 100.64.0.3 (or IP + 2) it will now be IP + 1. 
+  You can also find the DNS IP by going to Main Menu -> Advanced Settings -> Tunnel Configuration
+  
 * It is no longer possible to have the DNS server overlap the IP assigned to the interface
 
 ## Other changes:
@@ -9,9 +11,10 @@
 
 ## Bugs fixed:
 * [bug 560](https://github.com/openziti/desktop-edge-win/issues/560) - fix IP display on tunnel config page.
+* [bug 562](https://github.com/openziti/desktop-edge-win/issues/562) - fix mfa incorrectly reported when administratively deleted.
 
 ## Dependency Updates
-* TSDK updated to 0.19.8 / CSDK 0.29.4
+* TSDK updated to 0.19.9 / CSDK 0.29.4
 
 # Release 2.1.4
 

--- a/ziti-edge-tunnel/build.bat
+++ b/ziti-edge-tunnel/build.bat
@@ -14,7 +14,7 @@ REM See the License for the specific language governing permissions and
 REM limitations under the License.
 REM
 SET REPO_URL=https://github.com/openziti/ziti-tunnel-sdk-c.git
-SET ZITI_TUNNEL_REPO_BRANCH=v0.19.8
+SET ZITI_TUNNEL_REPO_BRANCH=v0.19.9
 REM override the c sdk used in the build - leave blank for the same as specified in the tunneler sdk
 SET ZITI_SDK_C_BRANCH=
 SET ZITI_TUNNEL_REPO_URL=https://github.com/openziti/ziti-tunnel-sdk-c/releases/latest/download/ziti-edge-tunnel-Windows_x86_64.zip


### PR DESCRIPTION
closes #562 

updates the tsdk so the tsdk doesn't send cached mfa to clients