### PR TITLE
update latest stream to 2.4.0

### DIFF
--- a/release-streams/latest.json
+++ b/release-streams/latest.json
@@ -1,12 +1,12 @@
 {
-  "name": "2.3.1",
-  "tag_name": "2.3.1",
-  "published_at": "2024-04-29T19:33:58Z",
+  "name": "2.4.0.0",
+  "tag_name": "2.4.0.0",
+  "published_at": "2024-07-11T12:00:00Z",
   "installation_critical": false,
   "assets": [
     {
-      "name": "Ziti.Desktop.Edge.Client-2.3.1.exe",
-      "browser_download_url": "https://github.com/openziti/desktop-edge-win/releases/download/2.3.1/Ziti.Desktop.Edge.Client-2.3.1.exe"
+      "name": "Ziti.Desktop.Edge.Client-2.4.0.0.exe",
+      "browser_download_url": "https://github.com/openziti/desktop-edge-win/releases/download/2.4.0.0/Ziti.Desktop.Edge.Client-2.4.0.0.exe"
     }
   ]
 }


### PR DESCRIPTION
2.4.0.0 was set to the latest release in github for legacy automatic upgrading. this PR will promote the 2.4.0.0 build to the 'latest' stream.

Current plan is to move 2.4.0.0 from latest to stable on Wednesday, July 24th assuming no bugs are reported or discovered to cause this plan to change.