### PR TITLE
remove unneeded active boolean from tunnel status

### DIFF
--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -1287,11 +1287,6 @@ namespace ZitiDesktopEdge {
 				_isServiceInError = false;
 				UpdateServiceView();
 				NoServiceView.Visibility = Visibility.Collapsed;
-				if (status.Active) {
-					SetNotifyIcon("green");
-				} else {
-					SetNotifyIcon("white");
-				}
 				if (!Application.Current.Properties.Contains("ip")) {
 					Application.Current.Properties.Add("ip", status?.IpInfo?.Ip);
 				} else {
@@ -1468,6 +1463,7 @@ namespace ZitiDesktopEdge {
 					DisconnectButton.Visibility = Visibility.Visible;
 					MainMenu.Connected();
 					HideLoad();
+					SetNotifyIcon("green");
 				} else {
 					ConnectButton.Visibility = Visibility.Visible;
 					DisconnectButton.Visibility = Visibility.Collapsed;
@@ -1477,6 +1473,7 @@ namespace ZitiDesktopEdge {
 					MainMenu.Disconnected();
 					DownloadSpeed.Content = "0.0";
 					UploadSpeed.Content = "0.0";
+					SetNotifyIcon("white");
 				}
 			});
 		}

--- a/ZitiDesktopEdge.Client/DataStructures/DataStructures.cs
+++ b/ZitiDesktopEdge.Client/DataStructures/DataStructures.cs
@@ -380,8 +380,6 @@ namespace ZitiDesktopEdge.DataStructures {
 
     public class TunnelStatus
     {
-        public bool Active { get; set; }
-
         public long Duration { get; set; }
 
         public List<Identity> Identities { get; set; }
@@ -397,7 +395,6 @@ namespace ZitiDesktopEdge.DataStructures {
         public void Dump(System.IO.TextWriter writer)
         {
             try {
-                writer.WriteLine($"Tunnel Active: {Active}");
                 writer.WriteLine($"     LogLevel         : {LogLevel}");
                 writer.WriteLine($"     EvaluatedLogLevel: {EvaluateLogLevel()}");
                 foreach (Identity id in Identities) {


### PR DESCRIPTION
TunnelStatus.Active is unnecessary. If the IPC is active, it's active. If the IPC is not active, it's not. Minor tweaks to the build test release script to make local testing easier