### PR TITLE
Addressing bugs and improving the experience of the client.

### DIFF
--- a/DesktopEdge/MainWindow.xaml
+++ b/DesktopEdge/MainWindow.xaml
@@ -9,10 +9,10 @@
         mc:Ignorable="d"
         ShowInTaskbar="False"
         x:Name="MainUI"
-        Title="Ziti Desktop Edge" Height="520" 
-        Width="420" ResizeMode="NoResize" 
+        Title="Ziti Desktop Edge" Height="520"
+        Width="420" ResizeMode="NoResize"
         ClipToBounds="False"
-        Icon="Assets/Images/icon.png" AllowsTransparency="True" 
+        Icon="Assets/Images/icon.png" AllowsTransparency="True"
         Closing="Window_Closing"
         i:MouseWheel.Enhanced="True"
         i:MouseWheel.LogicalScrollDebouncing="Auto"
@@ -113,7 +113,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Canvas x:Name="ArrowCanvas" ClipToBounds="False">
-            <Rectangle x:Name="Arrow" HorizontalAlignment="Center" Height="20" Fill="#070826" Width="20" ClipToBounds="True" Canvas.Left="185" Canvas.Bottom="-10">
+            <Rectangle x:Name="Arrow" HorizontalAlignment="Center" Height="20" Fill="#070826" Width="20" ClipToBounds="True">
                 <Rectangle.LayoutTransform>
                     <RotateTransform Angle="-45"/>
                 </Rectangle.LayoutTransform>
@@ -137,21 +137,29 @@
                     <ColumnDefinition Width="100"/>
                 </Grid.ColumnDefinitions>
                 <StackPanel Grid.Column="0" Cursor="Hand" Orientation="Vertical" Margin="14,16,14,14" MouseLeftButtonUp="ShowMenu">
-                    <Image Source="/Assets/Images/hamburger.png" Margin="5,0,0,-4" Width="26" Height="26" HorizontalAlignment="Left"></Image>
+                    <Image Source="/Assets/Images/hamburger.png" Margin="5,0,0,-4" Width="26" Height="26" HorizontalAlignment="Left">
+                        <Image.Effect>
+                            <DropShadowEffect Color="white" BlurRadius="1" ShadowDepth="1" Direction="90" Opacity="1" />
+                        </Image.Effect>
+                    </Image>
                     <Label Content="MAIN" FontFamily="pack://application:,,,/Assets/Fonts/#Open Sans" Foreground="White" Height="25" FontSize="10"></Label>
                     <Label Content="MENU" FontFamily="pack://application:,,,/Assets/Fonts/#Open Sans" Foreground="White" Height="25" Margin="0,-14,0,0" FontSize="10"></Label>
                 </StackPanel>
-                <StackPanel Grid.Column="1" Orientation="Vertical" HorizontalAlignment="Stretch" Margin="0,12" MouseDown="Window_MouseDown">
-                    <Image Source="/Assets/Images/z.png" Height="40" RenderOptions.BitmapScalingMode="Fant"></Image>
-                    <Label Content="Tap to Connect" MouseDoubleClick="Label_MouseDoubleClick" Margin="0,-3,0,0" FontFamily="pack://application:,,,/Assets/Fonts/#Russo One" FontSize="14" Foreground="White" HorizontalAlignment="Center"></Label>
+                <StackPanel Grid.Column="1" Orientation="Vertical" HorizontalAlignment="Stretch" Margin="0,12">
+                    <Image Source="/Assets/Images/z.png" Height="40" RenderOptions.BitmapScalingMode="Fant" MouseDown="Window_MouseDown" Cursor="ScrollAll" ToolTip="MOUSELEFT+DRAG to Detach/Move | MOUSERIGHT to Reattach"></Image>
+                    <Label Content="Tap to Toggle Service" Margin="0,-3,0,0" FontFamily="pack://application:,,,/Assets/Fonts/#Open Sans" FontSize="12" Foreground="White" HorizontalAlignment="Center"></Label>
                 </StackPanel>
                 <StackPanel x:Name="AddIdAreaButton" Grid.Column="2" Cursor="Hand" Orientation="Vertical" Margin="14,16,14,14" MouseLeftButtonUp="AddIdentity">
-                    <Image Source="/Assets/Images/identity.png" Margin="0,0,5,-4" Width="26" Height="26" HorizontalAlignment="Right"></Image>
+                    <Image Source="/Assets/Images/identity.png" Margin="0,0,5,-4" Width="26" Height="26" HorizontalAlignment="Right">
+                        <Image.Effect>
+                            <DropShadowEffect Color="white" BlurRadius="1" ShadowDepth="1" Direction="90" Opacity="1" />
+                        </Image.Effect>
+                    </Image>
                     <Label Content="ADD" FontFamily="pack://application:,,,/Assets/Fonts/#Open Sans" Foreground="White" Height="25" FontSize="10" HorizontalAlignment="Right"></Label>
                     <Label Content="IDENTITY" FontFamily="pack://application:,,,/Assets/Fonts/#Open Sans" Foreground="White" Height="25" Margin="0,-14,0,0" FontSize="10" HorizontalAlignment="Right"></Label>
                 </StackPanel>
             </Grid>
-            <Canvas Name="ConnectButton" Width="400" Height="160" MouseUp="StartZitiService" Visibility="Collapsed">
+            <Canvas Name="ConnectButton" Cursor="Hand" Width="400" Height="160" MouseUp="StartZitiService" Visibility="Collapsed">
                 <Grid Width="{Binding ActualWidth, ElementName=ConnectButton}" Height="140">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="221*"/>
@@ -160,7 +168,7 @@
                     <Image Source="/Assets/Images/connect.png" Height="140" HorizontalAlignment="Center" Grid.ColumnSpan="2" Margin="105,0" />
                 </Grid>
             </Canvas>
-            <Canvas Name="DisconnectButton" Width="400" Height="160" MouseUp="Disconnect" Visibility="Collapsed">
+            <Canvas Name="DisconnectButton" Cursor="Hand" Width="400" Height="160" MouseUp="Disconnect" Visibility="Collapsed">
                 <Grid Width="{Binding ActualWidth, ElementName=DisconnectButton}" Height="140">
                     <Image Source="/Assets/Images/connected.png" Height="140" HorizontalAlignment="Center" />
                 </Grid>
@@ -223,7 +231,7 @@
         <local:IdentityDetails x:Name="IdentityMenu" Visibility="Collapsed" OnMFAToggled="MFAToggled" Authenticate="ShowAuthenticate" Recovery="ShowRecovery" OnLoading="DoLoading" OnShowMFA="ShowAuthenticate"></local:IdentityDetails>
 
         <!-- Modal Background -->
-        <Rectangle x:Name="ModalBg" MouseDown="Window_MouseDown" Margin="10,10,10,10" Fill="Black" RadiusY="10" RadiusX="10" Opacity="0" Visibility="Collapsed"></Rectangle>
+        <Rectangle x:Name="ModalBg" Margin="10,10,10,10" Fill="Black" RadiusY="10" RadiusX="10" Opacity="0" Visibility="Collapsed"></Rectangle>
         <!-- MFA Setup Prompt -->
         <local:MFAScreen x:Name="MFASetup" Visibility="Collapsed" Margin="0,0,0,0" OnClose="DoClose"></local:MFAScreen>
 
@@ -257,7 +265,7 @@
             </Grid>
         </Grid>
 
-        <Grid x:Name="NoServiceView" Visibility="Collapsed" Margin="10,10,10,10">
+        <Grid x:Name="NoServiceView" Visibility="Collapsed" Margin="15,15,15,15">
             <Rectangle RadiusX="10" RadiusY="10">
                 <Rectangle.Fill>
                     <SolidColorBrush Color="Black" Opacity="0.9"/>
@@ -298,7 +306,7 @@
             </Grid>
         </Grid>
 
-        <Grid x:Name="LoadingScreen" MouseDown="Window_MouseDown" Visibility="Collapsed" Margin="10,10,10,10">
+        <Grid x:Name="LoadingScreen" Visibility="Collapsed" Margin="15,15,15,15">
             <Rectangle RadiusX="10" RadiusY="10">
                 <Rectangle.Fill>
                     <SolidColorBrush Color="Black" Opacity="0.9"/>
@@ -323,7 +331,7 @@
             </Grid>
         </Grid>
 
-        <Grid x:Name="ErrorView" MouseDown="Window_MouseDown" Visibility="Collapsed" Margin="10,10,10,10">
+        <Grid x:Name="ErrorView" Visibility="Collapsed" Margin="15,15,15,15">
             <Rectangle RadiusX="10" RadiusY="10">
                 <Rectangle.Fill>
                     <SolidColorBrush Color="Black" Opacity="0.9"/>

--- a/DesktopEdge/Models/ZitiIdentity.cs
+++ b/DesktopEdge/Models/ZitiIdentity.cs
@@ -147,7 +147,7 @@ namespace ZitiDesktopEdge.Models {
 #if DEBUG
             zid.MFADebug("002");
 #endif
-            if (id.Services != null) {
+            if (id.Services != null && id.Services.Count > 0) {
                 foreach (var svc in id.Services) {
                     if (svc != null) {
                         var zsvc = new ZitiService(svc);

--- a/DesktopEdge/Views/ItemRenderers/IdentityItem.xaml
+++ b/DesktopEdge/Views/ItemRenderers/IdentityItem.xaml
@@ -1,10 +1,10 @@
 ﻿<UserControl x:Class="ZitiDesktopEdge.IdentityItem"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:ZitiDesktopEdge"
-             mc:Ignorable="d" 
+             mc:Ignorable="d"
              d:DesignHeight="64" d:DesignWidth="375" Height="64">
     <Canvas Name="MainArea" MouseEnter="Canvas_MouseEnter" MouseLeave="Canvas_MouseLeave">
         <Rectangle Fill="#0F0C28" HorizontalAlignment="Left" Stroke="Black" VerticalAlignment="Top" ClipToBounds="True"></Rectangle>
@@ -29,19 +29,19 @@
                 <Label Name="ToggleStatus" Grid.Column="0" Grid.Row="1" Margin="0,-5,0,0" Content="Enabled" Foreground="White" FontSize="11" Typography.Capitals="AllSmallCaps" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"></Label>
                 <Rectangle Fill="Transparent" Grid.Column="0" Grid.RowSpan="2" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Cursor="Hand" MouseUp="ToggledSwitch"></Rectangle>
 
-                <Label Name="IdName" MaxWidth="210" Grid.Row="0" Padding="0,0,26,0" Grid.Column="1" VerticalAlignment="Center" Margin="0,11,0,0" FontFamily="pack://application:,,,/Assets/Fonts/#Open Sans" FontSize="16" Foreground="White" HorizontalAlignment="Left">
-                    <TextBlock TextTrimming="CharacterEllipsis">Identity Name</TextBlock>
+                <Label MaxWidth="210" Grid.Row="0" Padding="0,0,0,0" Grid.Column="1" VerticalAlignment="Center" Margin="0,11,0,0" FontFamily="pack://application:,,,/Assets/Fonts/#Open Sans" FontSize="16" Foreground="White" HorizontalAlignment="Left">
+                    <TextBlock Name="IdName" TextTrimming="CharacterEllipsis">Identity Name</TextBlock>
                 </Label>
                 <Rectangle Fill="Transparent" Grid.RowSpan="2" Grid.Column="1" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Cursor="Hand" MouseUp="OpenDetails"></Rectangle>
 
-                <Label Name="IdUrl" Cursor="Hand" MouseUp="OpenDetails" MaxWidth="180" MinWidth="210" Grid.Column="1" Grid.Row="1" FontSize="11" Margin="0,-5,0,0" Padding="0,5,0,0" Typography.Capitals="AllSmallCaps" FontFamily="pack://application:,,,/Assets/Fonts/#Open Sans" Foreground="White" HorizontalAlignment="Left">
-                    <TextBlock TextTrimming="CharacterEllipsis"></TextBlock>
+                <Label Cursor="Hand" MouseUp="OpenDetails" MaxWidth="180" MinWidth="210" Grid.Column="1" Grid.Row="1" FontSize="11" Margin="0,-5,0,0" Padding="0,5,0,0" Typography.Capitals="AllSmallCaps" FontFamily="pack://application:,,,/Assets/Fonts/#Open Sans" Foreground="White" HorizontalAlignment="Left">
+                    <TextBlock Name="IdUrl" TextTrimming="CharacterEllipsis"></TextBlock>
                 </Label>
                 <Image Name="PostureTimedOut" Visibility="Collapsed" Grid.Column="2" Source="/Assets/Images/lockout.png" VerticalAlignment="Bottom" HorizontalAlignment="Center" RenderOptions.BitmapScalingMode="Fant" Width="26" Height="26" Margin="0,0,0,6" Cursor="Hand" MouseUp="MFAAuthenticate"></Image>
                 <Image Name="MfaRequired" Source="/Assets/Images/mfaoff.png" Grid.Column="2" Cursor="Hand" Width="50" Height="26" VerticalAlignment="Bottom" RenderOptions.BitmapScalingMode="Fant" Stretch="Uniform" Visibility="Visible" MouseUp="MFAAuthenticate"></Image>
                 <Image Name="ExtAuthRequired" Source="/Assets/Images/ext-auth-needed.png" Grid.Column="2" Cursor="Hand" Width="50" Height="26" VerticalAlignment="Bottom" RenderOptions.BitmapScalingMode="Fant" Stretch="Uniform" Visibility="Visible" MouseUp="CompleteExtAuth"></Image>
                 <Canvas Name="ServiceCountArea" Grid.Column="2" Grid.Row="0" Width="50" Height="40" Cursor="Hand" Visibility="Collapsed">
-					<Border Name="ServiceCountBorder" Width="44" Height="26" Background="#0068F9" CornerRadius="12" Canvas.Top="10" Canvas.Left="3"></Border>
+                    <Border Name="ServiceCountBorder" Width="44" Height="26" Background="#0068F9" CornerRadius="12" Canvas.Top="10" Canvas.Left="3"></Border>
                     <Label Name="ServiceCount" Width="50" Height="26" Canvas.Top="9" Padding="0,0,0,0" FontSize="14" Content="23" Foreground="White" HorizontalAlignment="Center" VerticalContentAlignment="Center" HorizontalContentAlignment="Center"></Label>
                 </Canvas>
                 <Image Name="TimerCountdown" Visibility="Collapsed" Grid.Column="2" Source="/Assets/Images/timer.png" VerticalAlignment="Bottom" HorizontalAlignment="Center" Width="26" Height="26" Margin="0,0,0,6" Cursor="Hand" MouseUp="MFAAuthenticate"></Image>

--- a/DesktopEdge/Views/ItemRenderers/IdentityItem.xaml.cs
+++ b/DesktopEdge/Views/ItemRenderers/IdentityItem.xaml.cs
@@ -223,9 +223,9 @@ namespace ZitiDesktopEdge {
                 ServiceCountArea.Visibility = Visibility.Collapsed;
             }
 
-            IdName.Content = _identity.Name;
-            IdUrl.Content = _identity.ControllerUrl;
-            if (_identity.ContollerVersion != null && _identity.ContollerVersion.Length > 0) IdUrl.Content = _identity.ControllerUrl + " at " + _identity.ContollerVersion;
+            IdName.Text = _identity.Name;
+            IdUrl.Text = _identity.ControllerUrl;
+            if (_identity.ContollerVersion != null && _identity.ContollerVersion.Length > 0) IdUrl.Text = _identity.ControllerUrl + " at " + _identity.ContollerVersion;
 
             ToggleStatus.Content = ((ToggleSwitch.Enabled) ? "ENABLED" : "DISABLED");
         }

--- a/DesktopEdge/Views/ItemRenderers/MenuEditItem.xaml
+++ b/DesktopEdge/Views/ItemRenderers/MenuEditItem.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:ZitiDesktopEdge"
              mc:Ignorable="d" MaxWidth="360"
-             d:DesignHeight="31" Height="31" HorizontalAlignment="Stretch" d:DesignWidth="350" Cursor="Hand">
+             d:DesignHeight="31" Height="31" HorizontalAlignment="Stretch" d:DesignWidth="350">
     <StackPanel Orientation="Vertical" Height="31">
         <Grid Height="30">
             <Grid.ColumnDefinitions>
@@ -13,7 +13,7 @@
                 <ColumnDefinition Width="1*"/>
             </Grid.ColumnDefinitions>
             <TextBox Name="MainLabel" Background="White" Height="30" FontWeight="Bold" IsReadOnly="True" HorizontalAlignment="Stretch" BorderThickness="0" ClipToBounds="True" Padding="0,6,3,0" Grid.Column="0" VerticalAlignment="Center" FontSize="12" FontFamily="pack://application:,,,/Assets/Fonts/#Open Sans" Foreground="Black"></TextBox>
-            <TextBox Name="MainEdit" Background="White" IsReadOnly="True" HorizontalAlignment="Stretch" Height="30" Grid.Column="1" BorderThickness="0" TextAlignment="Right" Padding="0,6,3,0" FontSize="12" FontFamily="pack://application:,,,/Assets/Fonts/#Open Sans" ></TextBox>
+            <TextBox Name="MainEdit" Cursor="ScrollWE" Background="White" IsReadOnly="True" HorizontalAlignment="Stretch" Height="30" Grid.Column="1" BorderThickness="0" TextAlignment="Right" Padding="0,6,3,0" FontSize="12" FontFamily="pack://application:,,,/Assets/Fonts/#Open Sans" ></TextBox>
         </Grid>
     </StackPanel>
 </UserControl>

--- a/DesktopEdge/Views/Screens/IdentityDetails.xaml
+++ b/DesktopEdge/Views/Screens/IdentityDetails.xaml
@@ -1,16 +1,16 @@
 ﻿<UserControl x:Class="ZitiDesktopEdge.IdentityDetails"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:ZitiDesktopEdge"
-             mc:Ignorable="d" 
+             mc:Ignorable="d"
              x:Name="IdentityArea"
              d:DesignHeight="500" d:DesignWidth="350" IsVisibleChanged="VisibilityChanged">
     <Grid>
         <!-- Border Arrow pointing to TaskBar -->
         <Canvas>
-            <Rectangle Name="Arrow" HorizontalAlignment="Center" Height="20" Fill="White" Width="20" Canvas.Left="185" ClipToBounds="True" Canvas.Bottom="-10">
+            <Rectangle Name="Arrow" HorizontalAlignment="Center" Height="20" Fill="White" Width="20" ClipToBounds="True">
                 <Rectangle.LayoutTransform>
                     <RotateTransform Angle="-45"/>
                 </Rectangle.LayoutTransform>
@@ -33,9 +33,9 @@
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="60"/>
                     </Grid.ColumnDefinitions>
-                    <Image x:Name="IsConnected" Grid.Column="0" Visibility="Visible" Source="/Assets/Images/online.png" Height="25" HorizontalAlignment="Right" Cursor="Hand" MouseUp="DoDisconnect" />
-                    <Image x:Name="IsDisconnected" Grid.Column="0" Visibility="Collapsed" Source="/Assets/Images/offline.png" Height="25" HorizontalAlignment="Right" Cursor="Hand" MouseUp="DoConnect" />
-                    <TextBlock x:Name="IdDetailName" MouseDown="Window_MouseDown" MaxWidth="220" Grid.Column="1" TextTrimming="CharacterEllipsis" HorizontalAlignment="Center" FontSize="14" FontWeight="Bold" FontFamily="pack://application:,,,/Assets/Fonts/#Open Sans" Foreground="#0F0F23" VerticalAlignment="Center" TextWrapping="NoWrap" />
+                    <Image x:Name="IsConnected" Grid.Column="0" Visibility="Collapsed" Source="/Assets/Images/online.png" Height="25" HorizontalAlignment="Right" Cursor="Hand" ToolTip="Tap to Disable this Identity" MouseUp="DoDisconnect" />
+                    <Image x:Name="IsDisconnected" Grid.Column="0" Visibility="Collapsed" Source="/Assets/Images/offline.png" Height="25" HorizontalAlignment="Right" Cursor="Hand" ToolTip="Tap to Enable this Identity" MouseUp="DoConnect" />
+                    <Label x:Name="IdDetailName" Content="IDENTITY DETAIL" MouseDown="Window_MouseDown" Cursor="ScrollAll" MaxWidth="220" Grid.Column="1" HorizontalAlignment="Center" FontSize="14" ToolTip="MOUSELEFT+DRAG to Detach/Move | MOUSERIGHT to Reattach" FontFamily="pack://application:,,,/Assets/Fonts/#Russo One" Foreground="#0F0F23" VerticalAlignment="Center" />
                     <Image Grid.Column="2" Cursor="Hand" Source="/Assets/Images/x.png" Width="20" Height="20" Margin="0,0,0,0" HorizontalAlignment="Left" MouseUp="HideMenu"></Image>
                 </Grid>
                 <Rectangle Margin="40,0,40,10" Fill="#070826" Height="1" RadiusY="10" RadiusX="10" Opacity="0.1"></Rectangle>
@@ -102,7 +102,7 @@
             </StackPanel>
             <local:StyledButton x:Name="ForgetIdentityButton" MinWidth="310" BgColor="#F4044D" Label="Forget This Identity" Margin="0,0,0,40" OnClick="ForgetIdentity" HorizontalAlignment="Center" VerticalAlignment="Bottom" />
         </Grid>
-        <Rectangle x:Name="ModalBg" Margin="10,10,10,10" Fill="Black" RadiusY="10" RadiusX="10" Opacity="0" Visibility="Collapsed" MouseDown="Window_MouseDown"></Rectangle>
+        <Rectangle x:Name="ModalBg" Margin="10,10,10,10" Fill="Black" RadiusY="10" RadiusX="10" Opacity="0" Visibility="Collapsed"></Rectangle>
 
         <!-- Expended Detail Modal for Details pop up on service list -->
         <Grid x:Name="DetailsArea" Visibility="Collapsed" Height="400" Margin="0,0,0,0">
@@ -142,19 +142,12 @@
         </Grid>
 
         <!-- Confirmation Prompt for confirming deletion -->
-        <Grid x:Name="ConfirmView" Visibility="Collapsed" Width="400">
+        <Grid x:Name="ConfirmView" Visibility="Collapsed" Width="400" Margin="15,15,15,15">
             <Rectangle RadiusX="10" RadiusY="10">
                 <Rectangle.Fill>
                     <SolidColorBrush Color="Black"/>
                 </Rectangle.Fill>
             </Rectangle>
-            <Canvas>
-                <Rectangle Name="ConfirmArrow" HorizontalAlignment="Center" Height="20" Fill="Black" Width="20" Canvas.Left="185" ClipToBounds="True" Canvas.Bottom="-10">
-                    <Rectangle.LayoutTransform>
-                        <RotateTransform Angle="-45"/>
-                    </Rectangle.LayoutTransform>
-                </Rectangle>
-            </Canvas>
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="200"></ColumnDefinition>

--- a/DesktopEdge/Views/Screens/IdentityDetails.xaml.cs
+++ b/DesktopEdge/Views/Screens/IdentityDetails.xaml.cs
@@ -34,7 +34,7 @@ using System.Diagnostics.Eventing.Reader;
 namespace ZitiDesktopEdge {
     /// <summary>
     /// Interaction logic for IdentityDetails.xaml
-    /// </summary> 
+    /// </summary>
     public partial class IdentityDetails : UserControl {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
@@ -46,7 +46,7 @@ namespace ZitiDesktopEdge {
         public delegate void MFAToggled(bool isOn);
         public event MFAToggled OnMFAToggled;
         public delegate void Detched(MouseButtonEventArgs e);
-        public event Detched OnDetach;
+        public event Detched HandleAttachment;
         public delegate void Mesage(string message);
         public event Mesage OnMessage;
         public delegate void OnAuthenticate(ZitiIdentity identity);
@@ -110,12 +110,10 @@ namespace ZitiDesktopEdge {
         public MenuIdentityItem SelectedIdentityMenu { get; set; }
 
         private void Window_MouseDown(object sender, MouseButtonEventArgs e) {
-            if (e.ChangedButton == MouseButton.Left) {
-                _isAttached = false;
-                OnDetach(e);
-            }
+            if (e.ChangedButton == MouseButton.Left) IsAttached = false;
+            else if (e.ChangedButton == MouseButton.Right) IsAttached = true;
+            HandleAttachment(e);
         }
-
 
         public bool IsAttached {
             get {
@@ -125,10 +123,8 @@ namespace ZitiDesktopEdge {
                 _isAttached = value;
                 if (_isAttached) {
                     Arrow.Visibility = Visibility.Visible;
-                    ConfirmArrow.Visibility = Visibility.Visible;
                 } else {
                     Arrow.Visibility = Visibility.Collapsed;
-                    ConfirmArrow.Visibility = Visibility.Collapsed;
                 }
             }
         }
@@ -176,10 +172,6 @@ namespace ZitiDesktopEdge {
                 _scroller.InvalidateScrollInfo();
             }
 
-            IsConnected.Visibility = Visibility.Collapsed;
-            IsDisconnected.Visibility = Visibility.Collapsed;
-            IsConnected.Visibility = Visibility.Collapsed;
-            IsDisconnected.Visibility = Visibility.Collapsed;
             MainDetailScroll.Visibility = Visibility.Collapsed;
             AuthMessageBg.Visibility = Visibility.Collapsed;
             AuthMessageLabel.Visibility = Visibility.Collapsed;
@@ -190,16 +182,20 @@ namespace ZitiDesktopEdge {
             ServiceCount.Visibility = Visibility.Visible;
 
             scrolledTo = 0;
-            IdDetailName.Text = _identity.Name;
-            IdDetailName.ToolTip = _identity.Name;
             IdentityMFA.IsOn = _identity.IsMFAEnabled;
             IdentityMFA.ToggleField.IsEnabled = true;
             IdentityMFA.ToggleField.Opacity = 1;
-            IsConnected.ToolTip = "Enabled - Click To Disable";
-            IsDisconnected.ToolTip = "Disabled - Click to Enable";
             IdServer.Value = _identity.ControllerUrl;
+            IdServer.ToolTip = _identity.ControllerUrl;
+            IdName.ToolTip = _identity.Name;
             IdName.Value = _identity.Name;
-
+            if (_identity.IsEnabled) {
+                IsDisconnected.Visibility = Visibility.Collapsed;
+                IsConnected.Visibility = Visibility.Visible;
+            } else {
+                IsDisconnected.Visibility = Visibility.Visible;
+                IsConnected.Visibility = Visibility.Collapsed;
+            }
 
 #if DEBUG
             _identity.MFADebug("UpdateView");

--- a/DesktopEdge/Views/Screens/MFAScreen.xaml
+++ b/DesktopEdge/Views/Screens/MFAScreen.xaml
@@ -1,11 +1,11 @@
 ﻿<UserControl x:Class="ZitiDesktopEdge.MFAScreen"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:ZitiDesktopEdge"
-             mc:Ignorable="d" 
-             d:DesignHeight="570" 
+             mc:Ignorable="d"
+             d:DesignHeight="570"
              d:DesignWidth="420">
     <Grid x:Name="MFAArea" Visibility="Visible" Margin="0,0,0,0">
         <Border Margin="10,10,10,10" BorderBrush="Black" BorderThickness="8" CornerRadius="10">
@@ -48,7 +48,7 @@
                 <RowDefinition Height="10"></RowDefinition>
                 <RowDefinition Height="30"></RowDefinition>
             </Grid.RowDefinitions>
-            <Label Content="Setup MFA" Grid.Row="0" FontSize="16" HorizontalAlignment="Center" FontWeight="Bold"></Label>
+            <Label Content="SETUP MFA" Foreground="white" Grid.Row="0" FontSize="14" HorizontalAlignment="Center" FontFamily="/ZitiDesktopEdge;component/Assets/Fonts/#Russo One"></Label>
             <Label x:Name="IdName" Content="Identity Name" Grid.Row="1" FontSize="12" Foreground="DarkGray" HorizontalAlignment="Center"></Label>
             <Image x:Name="MFAImage" MaxWidth="200" MaxHeight="200" Width="200" Height="200" RenderOptions.BitmapScalingMode="Fant" Stretch="UniformToFill" Source="/Assets/Images/qrcode.png" Margin="50,0,50,0" Grid.Row="2" />
             <TextBox x:Name="SecretCode" TextWrapping="WrapWithOverflow" Grid.Row="2" HorizontalAlignment="Center" VerticalAlignment="Center" IsReadOnly="True" BorderThickness="0"></TextBox>
@@ -57,8 +57,8 @@
                 <Label HorizontalAlignment="Center" Content=" or " Foreground="#000000" Cursor="Hand"></Label>
                 <Label x:Name="SecretButton" HorizontalAlignment="Center" Content="Show Secret" Foreground="#0069FF" MouseUp="ShowSecret" Cursor="Hand"></Label>
             </StackPanel>
-            <Label Content="enter the code below to finish setup" Grid.Row="4" FontSize="11" Foreground="DarkGray" HorizontalAlignment="Center"></Label>
-            <Label Content="Authentication Code" Grid.Row="5" FontSize="18" Foreground="#FFFFFF" HorizontalAlignment="Center" FontWeight="Bold" FontFamily="/ZitiDesktopEdge;component/Assets/Fonts/#Russo One"></Label>
+            <Label Content="Enter the code below to finish setup." Grid.Row="4" FontSize="11" Foreground="DarkGray" HorizontalAlignment="Center"></Label>
+            <Label Content="Authentication Code" Grid.Row="5" FontSize="14" Foreground="#FFFFFF" HorizontalAlignment="Center" FontWeight="Bold"></Label>
             <TextBox x:Name="SetupCode" MaxLength="6" Padding="0,5,0,0" Grid.Row="6" Keyboard.KeyUp="HandleKey" BorderThickness="0 0 0 0" TextAlignment="Center" FontSize="50">
                 <TextBox.Resources>
                     <Style TargetType="{x:Type Border}">

--- a/DesktopEdge/Views/Screens/MainMenu.xaml
+++ b/DesktopEdge/Views/Screens/MainMenu.xaml
@@ -1,16 +1,16 @@
 ﻿<UserControl x:Class="ZitiDesktopEdge.MainMenu"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:ZitiDesktopEdge"
-             mc:Ignorable="d" 
+             mc:Ignorable="d"
              x:Name="MainMenuArea"
              d:DesignHeight="400" d:DesignWidth="400" Margin="1,1,1,1">
-    
+
     <Grid>
         <Canvas>
-            <Rectangle Name="Arrow" HorizontalAlignment="Center" Height="20" Fill="White" VerticalAlignment="Bottom" Width="20" Canvas.Bottom="-10" Canvas.Left="185">
+            <Rectangle Name="Arrow" HorizontalAlignment="Center" Height="20" Fill="White" VerticalAlignment="Bottom" Width="20">
                 <Rectangle.LayoutTransform>
                     <RotateTransform Angle="-45"/>
                 </Rectangle.LayoutTransform>
@@ -36,7 +36,7 @@
                         <Image Source="/Assets/Images/lastArrow.png" Width="20" Height="20"></Image>
                         <Label FontSize="12" FontWeight="SemiBold" Content="Back" FontFamily="pack://application:,,,/Assets/Fonts/#Open Sans"></Label>
                     </StackPanel>
-                    <Label Name="MenuTitle" MouseDown="Window_MouseDown" Grid.Column="1" Content="Main Menu" HorizontalAlignment="Center" FontSize="14" FontWeight="SemiBold" FontFamily="pack://application:,,,/Assets/Fonts/#Open Sans" Foreground="#0F0F23"></Label>
+                    <Label Name="MenuTitle" MouseDown="Window_MouseDown" Cursor="ScrollAll" ToolTip="MOUSELEFT+DRAG to Detach/Move | MOUSERIGHT to Reattach" Grid.Column="1" Content="MAIN MENU" HorizontalAlignment="Center" FontSize="16" FontFamily="pack://application:,,,/Assets/Fonts/#Russo One" Foreground="#0F0F23"></Label>
                     <Image Grid.Column="2" Cursor="Hand" Source="/Assets/Images/x.png" Height="20" Margin="50,4,0,5" MouseUp="HideMenu"></Image>
                 </Grid>
                 <Rectangle HorizontalAlignment="Stretch" Height="1" Fill="#7d8faf" Opacity="0.2"></Rectangle>
@@ -44,7 +44,7 @@
                     <local:MenuItem x:Name="IdentitiesButton" Label="Identities" Icon="/Assets/Images/identities.png" MouseUp="ShowIdentities"></local:MenuItem>
                     <local:MenuItem HorizontalAlignment="Stretch" Width="Auto" MouseUp="ShowAdvanced" Label="Advanced Settings" Icon="/Assets/Images/advanced.png"></local:MenuItem>
                     <local:MenuItem Label="About" Icon="/Assets/Images/about.png" MouseUp="ShowAbout"></local:MenuItem>
-					<local:MenuItem Label="Feedback" Icon="/Assets/Images/feedback.png" MouseUp="CollectFeedbackLogs"></local:MenuItem>
+                    <local:MenuItem Label="Feedback" Icon="/Assets/Images/feedback.png" MouseUp="CollectFeedbackLogs"></local:MenuItem>
                     <local:MenuItem Label="Support" Icon="/Assets/Images/support.png" MouseUp="ShowSupport"></local:MenuItem>
                     <local:MenuItem x:Name="DetachButton" Label="Detach App" Icon="/Assets/Images/detach.png" MouseUp="DetachWindow"></local:MenuItem>
                     <local:MenuItem x:Name="AttachButton" Label="Attach App" Icon="/Assets/Images/detach.png" MouseUp="RetachWindow" Visibility="Collapsed"></local:MenuItem>
@@ -62,7 +62,7 @@
                     <local:SubMenuItem HorizontalAlignment="Stretch" Width="Auto" Label="Terms of Service" MouseUp="ShowTerms"></local:SubMenuItem>
                 </StackPanel>
                 <StackPanel Name="AdvancedItems" Visibility="Collapsed" Orientation="Vertical" HorizontalAlignment="Stretch">
-                    <local:MenuItem HorizontalAlignment="Stretch" Icon="/Assets/Images/wrench.png" Width="Auto" Label="Tunnel Configuration" MouseUp="ShowConfig"></local:MenuItem>
+                    <local:MenuItem HorizontalAlignment="Stretch" Icon="/Assets/Images/wrench.png" Width="Auto" Label="Tunnel Config" MouseUp="ShowConfig"></local:MenuItem>
                     <local:MenuItem HorizontalAlignment="Stretch" Icon="/Assets/Images/logs.png" Width="Auto" Label="Service Logs" MouseUp="ShowLogs"></local:MenuItem>
                     <local:MenuItem HorizontalAlignment="Stretch" Icon="/Assets/Images/logs.png" Width="Auto" Label="Application Logs" MouseUp="ShowUILogs"></local:MenuItem>
                     <local:MenuItem HorizontalAlignment="Stretch" Icon="/Assets/Images/advanced.png" Width="Auto" Label="Set Logging Level" MouseUp="SetLogLevel"></local:MenuItem>
@@ -234,10 +234,10 @@
                     <local:StyledButton x:Name="CheckForUpdate" OnClick="CheckForUpdate_OnClick" Label="Check for Updates Now" Margin="0,20,0,0"></local:StyledButton>
                     <Label HorizontalAlignment="Center" x:Name="CheckForUpdateStatus" Content=""></Label>
 
-                    <Button x:Name="TriggerUpdateButton" 
-                            Click="TriggerUpdate_RoutedEventArgs_Click" 
-                            Visibility="Collapsed" 
-                            Content="Perform Update" 
+                    <Button x:Name="TriggerUpdateButton"
+                            Click="TriggerUpdate_RoutedEventArgs_Click"
+                            Visibility="Collapsed"
+                            Content="Perform Update"
                             Style="{StaticResource TestButton}"/>
 
                 </StackPanel>
@@ -265,9 +265,9 @@
                 <Label Name="MainItemsButton" Margin="0,10,0,0" Foreground="#F4044D" FontWeight="SemiBold" Content="Quit Ziti Desktop Edge" Cursor="Hand" MouseUp="CloseApp" FontFamily="pack://application:,,,/Assets/Fonts/#Open Sans" HorizontalAlignment="Center"></Label>
             </StackPanel>
         </Grid>
-        
+
         <!-- Modal for Menu Items: Next revision make one global modal -->
-        <Rectangle x:Name="ModalBg" MouseDown="Window_MouseDown" Margin="10,10,10,10" Fill="Black" RadiusY="10" RadiusX="10" Opacity="0" Visibility="Collapsed"></Rectangle>
+        <Rectangle x:Name="ModalBg" Margin="10,10,10,10" Fill="Black" RadiusY="10" RadiusX="10" Opacity="0" Visibility="Collapsed"></Rectangle>
 
         <!-- Modal For modifying the config data -->
         <Grid x:Name="EditArea" Visibility="Collapsed" Height="400" Margin="0,0,0,0">
@@ -285,7 +285,7 @@
                 </Rectangle.Fill>
             </Rectangle>
             <StackPanel x:Name="DetailPanel" Grid.Column="0" Orientation="Vertical" Margin="20,20,20,20" VerticalAlignment="Center" FocusVisualStyle="{x:Null}">
-                
+
                 <Label Content="IP Address" Padding="10,0,0,0"  FontWeight="Bold" FontSize="14" FontFamily="pack://application:,,,/Assets/Fonts/#Open Sans" Foreground="Black"></Label>
                 <TextBox x:Name="ConfigIpNew" Padding="10" Margin="10,10,10,10" Height="40" BorderThickness="1" TextAlignment="Left" FontSize="14" Foreground="Black" FontFamily="pack://application:,,,/Assets/Fonts/#Open Sans">
                     <TextBox.Resources>

--- a/DesktopEdge/Views/Screens/MainMenu.xaml.cs
+++ b/DesktopEdge/Views/Screens/MainMenu.xaml.cs
@@ -46,7 +46,7 @@ namespace ZitiDesktopEdge {
         public delegate Task<bool> LogLevelChanged(string level);
         public event LogLevelChanged OnLogLevelChanged;
         public delegate void Detched(MouseButtonEventArgs e);
-        public event Detched OnDetach;
+        public event Detched HandleAttachment;
         public delegate void ShowBlurb(string message);
         public event ShowBlurb OnShowBlurb;
         public string menuState = "Main";
@@ -102,9 +102,7 @@ namespace ZitiDesktopEdge {
             MainMenuArea.Visibility = Visibility.Collapsed;
         }
         private void Window_MouseDown(object sender, MouseButtonEventArgs e) {
-            if (e.ChangedButton == MouseButton.Left) {
-                OnDetach(e);
-            }
+            HandleAttachment(e);
         }
 
         private void CloseApp(object sender, MouseButtonEventArgs e) {
@@ -226,15 +224,15 @@ namespace ZitiDesktopEdge {
                 VersionInfo.Content = $"App: {appVersion} Service: {version}";
 
             } else if (menuState == "Advanced") {
-                MenuTitle.Content = "Advanced Settings";
+                MenuTitle.Content = "ADVANCED SETTINGS";
                 AdvancedItems.Visibility = Visibility.Visible;
                 BackArrow.Visibility = Visibility.Visible;
             } else if (menuState == "Licenses") {
-                MenuTitle.Content = "Third Party Licenses";
+                MenuTitle.Content = "THIRD PARTY LICENSES";
                 LicensesItems.Visibility = Visibility.Visible;
                 BackArrow.Visibility = Visibility.Visible;
             } else if (menuState == "Logs") {
-                MenuTitle.Content = "Advanced Settings";
+                MenuTitle.Content = "ADVANCED SETTINGS";
                 AdvancedItems.Visibility = Visibility.Visible;
                 //string targetFile = NativeMethods.GetFinalPathName(MainWindow.ExpectedLogPathServices);
                 string targetFile = MainWindow.ExpectedLogPathServices;
@@ -242,24 +240,24 @@ namespace ZitiDesktopEdge {
                 OpenLogFile("service", targetFile);
                 BackArrow.Visibility = Visibility.Visible;
             } else if (menuState == "UILogs") {
-                MenuTitle.Content = "Advanced Settings";
+                MenuTitle.Content = "ADVANCED SETTINGS";
                 AdvancedItems.Visibility = Visibility.Visible;
                 OpenLogFile("UI", MainWindow.ExpectedLogPathUI);
                 BackArrow.Visibility = Visibility.Visible;
             } else if (menuState == "LogLevel") {
                 ResetLevels();
 
-                MenuTitle.Content = "Set Log Level";
+                MenuTitle.Content = "SET LOG LEVEL";
                 LogLevelItems.Visibility = Visibility.Visible;
                 BackArrow.Visibility = Visibility.Visible;
             } else if (menuState == "ConfigureAutomaticUpgrades") {
                 SetAutomaticUpgradesState();
 
-                MenuTitle.Content = "Automatic Upgrades";
+                MenuTitle.Content = "AUTOMATIC UPGRADES";
                 AutomaticUpgradesItems.Visibility = Visibility.Visible;
                 BackArrow.Visibility = Visibility.Visible;
             } else if (menuState == "Config") {
-                MenuTitle.Content = "Tunnel Configuration";
+                MenuTitle.Content = "TUNNEL CONFIG";
                 ConfigItems.Visibility = Visibility.Visible;
                 BackArrow.Visibility = Visibility.Visible;
 
@@ -270,11 +268,11 @@ namespace ZitiDesktopEdge {
                 ConfigDns.Value = Application.Current.Properties["dns"]?.ToString();
                 ConfigDnsEnabled.Value = Application.Current.Properties["dnsenabled"]?.ToString();
             } else if (menuState == "Identities") {
-                MenuTitle.Content = "Identities";
+                MenuTitle.Content = "IDENTITIES";
                 IdListScrollView.Visibility = Visibility.Visible;
                 BackArrow.Visibility = Visibility.Visible;
             } else {
-                MenuTitle.Content = "Main Menu";
+                MenuTitle.Content = "MAIN MENU";
                 MainItems.Visibility = Visibility.Visible;
                 MainItemsButton.Visibility = Visibility.Visible;
             }
@@ -380,6 +378,12 @@ namespace ZitiDesktopEdge {
             DetachButton.Visibility = Visibility.Collapsed;
             AttachButton.Visibility = Visibility.Visible;
             Arrow.Visibility = Visibility.Collapsed;
+        }
+        public void Retach() {
+            Application.Current.MainWindow.ShowInTaskbar = false;
+            DetachButton.Visibility = Visibility.Visible;
+            AttachButton.Visibility = Visibility.Collapsed;
+            Arrow.Visibility = Visibility.Visible;
         }
         private void RetachWindow(object sender, MouseButtonEventArgs e) {
             Application.Current.MainWindow.ShowInTaskbar = false;


### PR DESCRIPTION
- BUGFIX:  Fix issue with [Main View] bottom clipping.  
  - WHY? When toggling the service on/off, the bottom of the application clipped off.

- BUGFIX:  Fix issue with [Main Menu]>[Identities]>[Individual Identity Screen](Image/Button, TOP LEFT) "Enabled/Disabled" image.
  - WHY? The image had become collapsed permanently and was not visible for toggle of service in this view.

- BUGFIX: Fix issue with window attachment conformity across different views.
  - WHY? In some instances the attach/detach functionality would become out of sync.

- BUGFIX: Fix issue with overlay size and detailing for the view "IdentityDetails".
  - WHY? When "forget identity" is selected, the overlay was not sized correctly and made use of an arrow-to-taskbar that was not dynamically adjusted.

- BUGFIX: Fix issue with [Main View](IDList, MIDDLE CENTER) ID labels where the ellipsis effect was not properly applied.
  - WHY? Instead of an overflow clipping of the name/URL, it now properly shows the ellipsis indicator properly indicating that the name/URL was too long to display.

- BUGFIX: Fix issue with [Main View](IDList, MIDDLE CENTER) MFA Required indicator upon an identity.
  - WHY? The "ZitiIdentity.cs" model was missing a test which triggered a flag for posture checking to fail.

- ENHANCE: Embolden the [Main View](Image/Button, TOP RIGHT) "Add Identity" image.
  - WHY? So it matches the visual feel of the counter side's "Main Menu".

- ENHANCE: Added "HANDPOINTER" cursor when hovering over the [Main Screen](Image/Button, MIDDLE CENTER) "Connect/Disconnect" image.
  - WHY? For better representation of function.

- ENHANCE: Added "HANDPOINTER" cursor when hovering over the [ANY View](Text, TOP CENTER) title text with instructional tooltip for attach/detachment of the window from the task bar..
  - WHY? For better representation of function.

- ENHANCE: Changed content/font/size of [Main View](Label, TOP CENTER) text below the logo to Open Sans, 12pt, "Tap to Toggle Service".
  - WHY? For better representation of function.

- ENHANCE: Changes the title content of the [Main Menu]>[IdentityDetails View](Label, TOP CENTER) text to be a static label for the view and adds tooltip info to the name/url in the fields below.
  - WHY? The title is usually not big enough to house the identity name, so having it there made no sense.  Having a tooltip on the fields below where the id/url are makes much more sense for overflow reasons.

- ENHANCE: Updated function "Window_MouseDown" with new capability to handle a right click across all views.  
  - WHY? Uniformity for the functionality.

- ENHANCE: Changed the [Main View]>[MFA View] to be in visual alignment with the rest of the application.  
  - WHY? Look and feel alignment.

- ENHANCE: Changed the [Identity Detail View](Cursor Style) of the Name and Network text fields to better indicate the ability to select further than the boundaries.  
  - WHY? Copy into buffer is the purpose of having a textbox style for these fields, thus telling the user they can select more than what they see is important.