### PR TITLE
Aliveness check fix

### DIFF
--- a/ZitiUpdateService/UpdateService.cs
+++ b/ZitiUpdateService/UpdateService.cs
@@ -915,6 +915,8 @@ namespace ZitiUpdateService {
 
         private void stopProcessForcefully(string processName, string description) {
             try {
+                string logLocation = Path.Combine(exeLocation, "logs");
+
                 Logger.Info("Closing the {description} process", description);
                 Process[] workers = Process.GetProcessesByName(processName);
                 if (workers.Length < 1) {
@@ -928,6 +930,7 @@ namespace ZitiUpdateService {
 
                 foreach (Process worker in workers) {
                     try {
+                        MiniDump.CreateMemoryDump(worker, Path.Combine(logLocation, "ziti-edge-tunnel.stalled.dmp"));
                         Logger.Info("Killing: {0}", worker);
                         if (!worker.CloseMainWindow()) {
                             //don't care right now because when called on the UI it just gets 'hidden'

--- a/ZitiUpdateService/UpdateService.cs
+++ b/ZitiUpdateService/UpdateService.cs
@@ -542,34 +542,41 @@ namespace ZitiUpdateService {
         }
 
         private void zitiEdgeTunnelAlivenessCheck(object sender, ElapsedEventArgs e) {
+            bool succeeded = false;
             try {
                 if (zetSemaphore.Wait(TimeSpan.FromSeconds(zetHealthcheckInterval))) {
-                    Logger.Trace("ziti-edge-tunnel aliveness check starts");
+                    Logger.Trace("ziti-edge-tunnel aliveness check starts, zetSemaphore lock acquired");
                     dataClient.GetStatusAsync().Wait();
-                    zetSemaphore.Release();
-                    Interlocked.Exchange(ref zetFailedCheckCounter, 0);
                     Logger.Trace("ziti-edge-tunnel aliveness check ends successfully");
-                } else {
-                    Interlocked.Add(ref zetFailedCheckCounter, 1);
-                    Logger.Warn("ziti-edge-tunnel aliveness check appears blocked and has been for {0} times. AlivenessChecksBeforeAction:{1}", 
-                        zetFailedCheckCounter, CurrentSettings.AlivenessChecksBeforeAction);
-                    if (CurrentSettings.AlivenessChecksBeforeAction > 0) {
-                        if (zetFailedCheckCounter > CurrentSettings.AlivenessChecksBeforeAction) {
-                            disableHealthCheck();
-                            //after 'n' failures, just terminate ziti-edge-tunnel
-                            Interlocked.Exchange(ref zetFailedCheckCounter, 0); //reset the counter back to 0
-                            Logger.Warn("forcefully stopping ziti-edge-tunnel as it has been blocked for too long");
-                            stopProcessForcefully("ziti-edge-tunnel", "data service [ziti]");
-                            zetSemaphore.Release();
-
-                            Logger.Info("immediately restarting ziti-edge-tunnel");
-                            ServiceActions.StartService(); //attempt to start the service
-                        }
-                    }
+                    succeeded = true;
                 }
             } catch (Exception ex) {
                 Logger.Error("ziti-edge-tunnel aliveness check ends exceptionally: {}", ex.Message);
                 Logger.Error(ex);
+            }
+
+            if (succeeded) {
+                Interlocked.Exchange(ref zetFailedCheckCounter, 0);
+                zetSemaphore.Release();
+                Logger.Trace("zetFailedCheckCounter reset to 0 and zetSemaphore released");
+            } else {
+                Interlocked.Add(ref zetFailedCheckCounter, 1);
+                Logger.Warn("ziti-edge-tunnel aliveness check appears blocked and has been for {0} times. AlivenessChecksBeforeAction:{1}", zetFailedCheckCounter, CurrentSettings.AlivenessChecksBeforeAction);
+                if (CurrentSettings.AlivenessChecksBeforeAction > 0) {
+                    if (zetFailedCheckCounter > CurrentSettings.AlivenessChecksBeforeAction) {
+                        disableHealthCheck();
+                        //after 'n' failures, just terminate ziti-edge-tunnel
+                        Interlocked.Exchange(ref zetFailedCheckCounter, 0); //reset the counter back to 0
+                        zetSemaphore.Release();
+                        Logger.Trace("zetFailedCheckCounter reset to 0 and zetSemaphore released");
+
+                        Logger.Warn("forcefully stopping ziti-edge-tunnel as it has been blocked for too long");
+                        stopProcessForcefully("ziti-edge-tunnel", "data service [ziti]");
+
+                        Logger.Info("immediately restarting ziti-edge-tunnel");
+                        ServiceActions.StartService(); //attempt to start the service
+                    }
+                }
             }
         }
 

--- a/ZitiUpdateService/ZitiUpdateService.csproj
+++ b/ZitiUpdateService/ZitiUpdateService.csproj
@@ -164,6 +164,7 @@
       <DependentUpon>ProjectInstaller.cs</DependentUpon>
     </Compile>
     <Compile Include="checkers\UpdateCheckers.cs" />
+    <Compile Include="utils\MiniDump.cs" />
     <Compile Include="utils\Settings.cs" />
     <Compile Include="UpdateService.cs">
       <SubType>Component</SubType>

--- a/ZitiUpdateService/ZitiUpdateService.csproj
+++ b/ZitiUpdateService/ZitiUpdateService.csproj
@@ -178,13 +178,11 @@
     <Content Include="App.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <None Include="UpdateJsonExample.json" />
     <None Include="ZitiUpdateService-log.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="packages.config" />
     <None Include="Properties\app.manifest" />
-    <None Include="ZitiUpdateService_TemporaryKey.pfx" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="ProjectInstaller.resx">

--- a/ZitiUpdateService/utils/MiniDump.cs
+++ b/ZitiUpdateService/utils/MiniDump.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ZitiUpdateService {
+    using NLog;
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Runtime.InteropServices;
+
+    public class MiniDump {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+        [DllImport("dbghelp.dll", SetLastError = true)]
+        public static extern bool MiniDumpWriteDump(
+            IntPtr hProcess,
+            uint processId,
+            IntPtr hFile,
+            uint dumpType,
+            IntPtr exceptionParam,
+            IntPtr userStreamParam,
+            IntPtr callbackParam);
+
+        public const uint MiniDumpNormal = 0x00000000;
+        public const uint MiniDumpWithFullMemory = 0x00000002;
+        public const uint MiniDumpWithThreadInfo = 0x00000010;
+
+        public static void CreateMemoryDump(Process procToDump, string outputFile) {
+            try {
+                uint processId = (uint)procToDump.Id;
+
+                using (FileStream fs = new FileStream(outputFile, FileMode.Create)) {
+                    IntPtr hFile = fs.SafeFileHandle.DangerousGetHandle();
+
+                    // Create the dump using MiniDumpWriteDump
+                    bool result = MiniDumpWriteDump(
+                        procToDump.Handle,
+                        processId,
+                        hFile,
+                        MiniDumpWithThreadInfo,
+                        IntPtr.Zero,
+                        IntPtr.Zero,
+                        IntPtr.Zero);
+
+                    if (result) {
+                        Logger.Info("Memory dump created successfully at {}", outputFile);
+                    } else {
+                        Logger.Error("Failed to create memory dump?");
+                    }
+                }
+            } catch (Exception ex) {
+                Logger.Error("Unexpected error while creating memory dump: {}", ex.Message);
+            }
+        }
+    }
+}

--- a/ZitiUpdateService/utils/MiniDump.cs
+++ b/ZitiUpdateService/utils/MiniDump.cs
@@ -1,8 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
 
 namespace ZitiUpdateService {
     using NLog;


### PR DESCRIPTION
Rearranges how the aliveness check works. an unexpected error would leave the semaphore permanently locked. Also writes a mini dump if the process needs to be terminated by the monitor 