### PR TITLE
use better errors when using by URL add identity

### DIFF
--- a/DesktopEdge/Views/Controls/AddIdentityUrl.xaml.cs
+++ b/DesktopEdge/Views/Controls/AddIdentityUrl.xaml.cs
@@ -55,20 +55,20 @@ namespace ZitiDesktopEdge {
             } catch (Exception ex) {
                 Mouse.OverrideCursor = null;
                 this.OnClose?.Invoke(false, this);
-
+                MainWindow mw = ((MainWindow)Application.Current.MainWindow);
                 if (ex.InnerException is System.Net.WebException webEx) {
                     if (webEx.Status == System.Net.WebExceptionStatus.TrustFailure) {
-                        await ((MainWindow)Application.Current.MainWindow).ShowBlurbAsync("Untrusted certificate or TLS error", "");
+                        await mw.ShowBlurbAsync("Untrusted certificate or TLS error", "");
                         logger.Warn(ex, "TLS trust issue with URL");
                     } else if (webEx.Status == System.Net.WebExceptionStatus.NameResolutionFailure) {
-                        await ((MainWindow)Application.Current.MainWindow).ShowBlurbAsync("Invalid or unreachable host name", "");
+                        await mw.ShowBlurbAsync("Invalid or unreachable host name", "");
                         logger.Warn(ex, "Bunk URL or DNS resolution failed");
                     } else {
-                        await ((MainWindow)Application.Current.MainWindow).ShowBlurbAsync("Unexpected error accessing URL", "");
+                        await mw.ShowBlurbAsync("Unexpected error accessing URL", "");
                         logger.Warn(ex, "Could not connect to URL, status={0}", webEx.Status);
                     }
                 } else {
-                    await ((MainWindow)Application.Current.MainWindow).ShowBlurbAsync("Unexpected error accessing URL", "");
+                    await mw.ShowBlurbAsync("Unexpected error accessing URL", "");
                     logger.Warn(ex, "Unexpected exception {0}", ex.Message);
                 }
             }

--- a/DesktopEdge/Views/Controls/AddIdentityUrl.xaml.cs
+++ b/DesktopEdge/Views/Controls/AddIdentityUrl.xaml.cs
@@ -15,6 +15,7 @@
 */
 using NLog;
 using System;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -48,14 +49,28 @@ namespace ZitiDesktopEdge {
 
             Mouse.OverrideCursor = Cursors.Wait;
             try {
-                var result = client.GetAsync(ControllerURL.Text).Result;
+                var result = await client.GetAsync(ControllerURL.Text);
                 Mouse.OverrideCursor = null;
                 OnAddIdentity(payload, this);
-            } catch {
+            } catch (Exception ex) {
                 Mouse.OverrideCursor = null;
                 this.OnClose?.Invoke(false, this);
-                await ((MainWindow)Application.Current.MainWindow).ShowBlurbAsync("Timed out accessing URL", "");
-                logger.Warn("could not connect to url");
+
+                if (ex.InnerException is System.Net.WebException webEx) {
+                    if (webEx.Status == System.Net.WebExceptionStatus.TrustFailure) {
+                        await ((MainWindow)Application.Current.MainWindow).ShowBlurbAsync("Untrusted certificate or TLS error", "");
+                        logger.Warn(ex, "TLS trust issue with URL");
+                    } else if (webEx.Status == System.Net.WebExceptionStatus.NameResolutionFailure) {
+                        await ((MainWindow)Application.Current.MainWindow).ShowBlurbAsync("Invalid or unreachable host name", "");
+                        logger.Warn(ex, "Bunk URL or DNS resolution failed");
+                    } else {
+                        await ((MainWindow)Application.Current.MainWindow).ShowBlurbAsync("Unexpected error accessing URL", "");
+                        logger.Warn(ex, "Could not connect to URL, status={0}", webEx.Status);
+                    }
+                } else {
+                    await ((MainWindow)Application.Current.MainWindow).ShowBlurbAsync("Unexpected error accessing URL", "");
+                    logger.Warn(ex, "Unexpected exception {0}", ex.Message);
+                }
             }
         }
 

--- a/DesktopEdge/Views/Controls/AddIdentityUrl.xaml.cs
+++ b/DesktopEdge/Views/Controls/AddIdentityUrl.xaml.cs
@@ -59,10 +59,10 @@ namespace ZitiDesktopEdge {
                 if (ex.InnerException is System.Net.WebException webEx) {
                     if (webEx.Status == System.Net.WebExceptionStatus.TrustFailure) {
                         await mw.ShowBlurbAsync("Untrusted certificate or TLS error", "");
-                        logger.Warn(ex, "TLS trust issue with URL");
+                        logger.Warn(ex, "TLS trust issue with URL: {0}", ControllerURL.Text);
                     } else if (webEx.Status == System.Net.WebExceptionStatus.NameResolutionFailure) {
                         await mw.ShowBlurbAsync("Invalid or unreachable host name", "");
-                        logger.Warn(ex, "Bunk URL or DNS resolution failed");
+                        logger.Warn(ex, "Bunk URL or DNS resolution failed: {0}", ControllerURL.Text);
                     } else {
                         await mw.ShowBlurbAsync("Unexpected error accessing URL", "");
                         logger.Warn(ex, "Could not connect to URL, status={0}", webEx.Status);


### PR DESCRIPTION
closes #871 - users will now see:

<img width="385" height="74" alt="image" src="https://github.com/user-attachments/assets/7fd7be48-edbd-49a1-bff0-ec6629c35c68" />
<br/>
<img width="379" height="72" alt="image" src="https://github.com/user-attachments/assets/f0030096-7a9e-406e-9e5e-90481777e2c1" />

