### PR TITLE
Fix external auth toast notifications and single-provider auto-launch

### DIFF
--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -1318,7 +1318,7 @@ namespace ZitiDesktopEdge {
                                     string displayName = string.IsNullOrEmpty(found.Name) ? found.Identifier : found.Name;
                                     ShowToast("Authentication Successful", $"{displayName} has been authenticated.", null);
                                 }
-                            // identity still needs ext auth and no auth is currently in progress: queue a toast
+                                // identity still needs ext auth and no auth is currently in progress: queue a toast
                             } else if (isExtLogin && e.Id.NeedsExtAuth) {
                                 QueueExtAuthNotification(found);
                             }
@@ -1342,19 +1342,6 @@ namespace ZitiDesktopEdge {
                             }
                         }
                         LoadIdentities(true);
-                    }
-                } else if (e.Action == "needs_ext_login_do_not_match") {
-                    //this was here previously but was chnaged in https://github.com/openziti/desktop-edge-win/commit/4ce8d2c6
-                    //leaving here for history's sake at this point
-                    var found = identities.Find(i => i.Identifier == e.Id.Identifier);
-                    if (found != null) {
-                        if (found.AuthInProgress) {
-                            logger.Debug("Identity: {} with AuthInProgress received needs_ext_login event", found.Identifier);
-                        } else {
-                            // auth not in progress, mark as needs ext auth
-                            found.NeedsExtAuth = e.Id.NeedsExtAuth;
-                            LoadIdentities(true);
-                        }
                     }
                 } else if (e.Action == "updated") {
                     //this indicates that all updates have been sent to the UI... wait for 2 seconds then trigger any ui updates needed

--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -791,15 +791,16 @@ namespace ZitiDesktopEdge {
 
         private async void ServiceClient_OnAuthenticationEvent(object sender, AuthenticationEvent e) {
             ZitiIdentity found = identities.Find(i => i.Identifier == e.Identifier);
-            if(found != null) {
+            if (found != null) {
                 if (e.Action == "error") {
                     found.AuthInProgress = false;
                     await Dispatcher.BeginInvoke(new Action(async () => {
-                        if (!_notificationThrottle.Suppress) {
+                        if (_notificationThrottle.Suppress) {
+                            await ShowBlurbAsync("Authentication Failed", "External Auth Failed");
+                        } else {
                             string displayName = string.IsNullOrEmpty(found.Name) ? found.Identifier : found.Name;
                             ShowToast("Authentication Failed", $"{displayName} failed to authenticate externally.", null);
-                        } else {
-                            await ShowBlurbAsync("Authentication Failed", "External Auth Failed");
+
                         }
                     }));
                 }

--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -1120,6 +1120,9 @@ namespace ZitiDesktopEdge {
                 if (defaultProvider != null) {
                     DataClient client = (DataClient)Application.Current.Properties["ServiceClient"];
                     await identity.PerformExternalAuthEvent(client, identity.GetDefaultProviderId());
+                } else if (identity.ExtAuthProviders?.Count == 1) {
+                    DataClient client = (DataClient)Application.Current.Properties["ServiceClient"];
+                    await identity.PerformExternalAuthEvent(client, identity.ExtAuthProviders[0]);
                 } else {
                     OpenIdentity(identity);
                 }

--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -795,7 +795,12 @@ namespace ZitiDesktopEdge {
                 if (e.Action == "error") {
                     found.AuthInProgress = false;
                     await Dispatcher.BeginInvoke(new Action(async () => {
-                        await ShowBlurbAsync("Authentication Failed", "External Auth Failed");
+                        if (!_notificationThrottle.Suppress) {
+                            string displayName = string.IsNullOrEmpty(found.Name) ? found.Identifier : found.Name;
+                            ShowToast("Authentication Failed", $"{displayName} failed to authenticate externally.", null);
+                        } else {
+                            await ShowBlurbAsync("Authentication Failed", "External Auth Failed");
+                        }
                     }));
                 }
             }
@@ -1293,31 +1298,31 @@ namespace ZitiDesktopEdge {
                     } else {
                         var isAdd = e.Action == "added";
                         var isExtLogin = e.Action == "needs_ext_login";
-                        // means we are getting an update for some reason. compare the identities and use the latest info
-                        // for external auth, this event will return after external auth. track if the auth is in progress or not
-                        // and clear the flag here if it succeeds, else pop a 'auth failed'
+                        // identity already exists: handle ext auth state transitions.
+                        // ziti-edge-tunnel sends needs_ext_login immediately when ExternalAuthLogin is called.
+                        // that clears AuthInProgress so the subsequent added event with NeedsExtAuth=false
+                        // is treated as a successful auth in the else branch.
                         if (found.AuthInProgress) {
-                            if (isAdd) {
-                                found.AuthInProgress = false; //regardless clear it here
-                                if (zid.NeedsExtAuth) {
-                                    logger.Warn("Identity: {} AuthInProgress but still NeedsExtAuth? Check the tunneler logs", found.Identifier);
-                                    ShowError("Authentication Request Failed", "An error occurred preventing external authentication from succeeding. See the log and contact your administrator.");
-                                } else {
-                                    // happy path. this means auth was in progress and now the identity no longer requires exteral auth
-                                    logger.Info("Identity: {} successfully authenticated", found.Identifier);
-                                    _notificationThrottle.Remove(found.Identifier);
-                                }
-                            } else if (isExtLogin) {
-                                found.NeedsExtAuth = e.Id.NeedsExtAuth; // mark the identity as needing ext auth
-                            } else {
-                                logger.Debug("unexpected situation. if auth is in progress either it should be an add or ext-auth-login action");
+                            // ext auth started: dequeue the authenticate toast and reset state
+                            if (isExtLogin) {
+                                _notificationThrottle.Remove(found.Identifier);
+                                found.AuthInProgress = false;
+                                found.NeedsExtAuth = e.Id.NeedsExtAuth;
                             }
                         } else {
-                            // auth not in progress, mark as needs ext auth
-                            found.NeedsExtAuth = e.Id.NeedsExtAuth;
-                            if (isExtLogin && found.NeedsExtAuth) {
+                            // ext auth completed: identity no longer needs ext auth
+                            if (isAdd && found.NeedsExtAuth && !e.Id.NeedsExtAuth) {
+                                logger.Info("Identity: {} successfully authenticated", found.Identifier);
+                                _notificationThrottle.Remove(found.Identifier);
+                                if (!_notificationThrottle.Suppress) {
+                                    string displayName = string.IsNullOrEmpty(found.Name) ? found.Identifier : found.Name;
+                                    ShowToast("Authentication Successful", $"{displayName} has been authenticated.", null);
+                                }
+                            // identity still needs ext auth and no auth is currently in progress: queue a toast
+                            } else if (isExtLogin && found.NeedsExtAuth) {
                                 QueueExtAuthNotification(found);
                             }
+                            found.NeedsExtAuth = e.Id.NeedsExtAuth;
                         }
                         if (zid.Name != null && zid.Name.Length > 0) found.Name = zid.Name;
                         if (zid.ControllerUrl != null && zid.ControllerUrl.Length > 0) found.ControllerUrl = zid.ControllerUrl;

--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -1319,7 +1319,7 @@ namespace ZitiDesktopEdge {
                                     ShowToast("Authentication Successful", $"{displayName} has been authenticated.", null);
                                 }
                             // identity still needs ext auth and no auth is currently in progress: queue a toast
-                            } else if (isExtLogin && found.NeedsExtAuth) {
+                            } else if (isExtLogin && e.Id.NeedsExtAuth) {
                                 QueueExtAuthNotification(found);
                             }
                             found.NeedsExtAuth = e.Id.NeedsExtAuth;

--- a/DesktopEdge/Models/ZitiIdentity.cs
+++ b/DesktopEdge/Models/ZitiIdentity.cs
@@ -289,16 +289,17 @@ namespace ZitiDesktopEdge.Models {
                         logger.Info("beginning external auth using url: {}", resp.Data?.url);
                         Process.Start(resp.Data.url);
                     } else {
+                        AuthInProgress = false;
                         errMsg = "External authentication could not start. No URL was returned to login. Inform your network administrator.";
                     }
                 } else {
+                    AuthInProgress = false;
                     errMsg = resp.Error;
                 }
             } catch (Exception ex) {
                 AuthInProgress = false;
                 throw new Exception("unexpected error during external authentication!", ex);
             }
-            AuthInProgress = false;
             if (errMsg != null) {
                 throw new Exception(errMsg);
             }

--- a/DesktopEdge/Views/ItemRenderers/IdentityItem.xaml.cs
+++ b/DesktopEdge/Views/ItemRenderers/IdentityItem.xaml.cs
@@ -402,7 +402,6 @@ namespace ZitiDesktopEdge {
                     return;
                 }
                 if (_identity?.ExtAuthProviders?.Count > 0) {
-                    _identity.AuthInProgress = false;
                     try {
                         string defaultProvider = _identity.GetDefaultProviderId();
                         DataClient client = (DataClient)Application.Current.Properties["ServiceClient"];

--- a/DesktopEdge/Views/ItemRenderers/IdentityItem.xaml.cs
+++ b/DesktopEdge/Views/ItemRenderers/IdentityItem.xaml.cs
@@ -402,17 +402,14 @@ namespace ZitiDesktopEdge {
                     return;
                 }
                 if (_identity?.ExtAuthProviders?.Count > 0) {
-                    if (_identity.AuthInProgress) {
-                        BlurbEvent?.Invoke(_identity);
-                    } else {
-                        try {
-                            string defaultProvider = _identity.GetDefaultProviderId();
-                            DataClient client = (DataClient)Application.Current.Properties["ServiceClient"];
-                            await _identity.PerformExternalAuthEvent(client, defaultProvider);
-                        } catch (Exception ex) {
-                            ShowError("Unexpected Error", "Please report this issue: " + ex.Message);
-                            logger.Error("external auth failed: [{}]", ex.Message);
-                        }
+                    _identity.AuthInProgress = false;
+                    try {
+                        string defaultProvider = _identity.GetDefaultProviderId();
+                        DataClient client = (DataClient)Application.Current.Properties["ServiceClient"];
+                        await _identity.PerformExternalAuthEvent(client, defaultProvider);
+                    } catch (Exception ex) {
+                        ShowError("Unexpected Error", "Please report this issue: " + ex.Message);
+                        logger.Error("external auth failed: [{}]", ex.Message);
                     }
                 } else {
                     ShowError("Failed to Authenticate", "No external providers found! This is a configuration error. Inform your network administrator.");

--- a/manual-testing.md
+++ b/manual-testing.md
@@ -6,26 +6,21 @@ These are the tests you need to make sure to perform per release.
 
 - Identity with dial access to a single service
 - Identity with bind access to a single service
-- Identity with dial access to a service with by TOTP posture check
-- Identity with dial access to a service with by TOTP + time-based posture check
-- Identity with dial access to a service with by TOTP + on-wake locking posture check
-
+- Identity with dial access to a service with TOTP posture check
+- Identity with dial access to a service with TOTP + time-based posture check
+- Identity with dial access to a service with TOTP + on-wake locking posture check
 - Identity with dial access to a service with process-based posture check
-- Identity with dial access to a service with by posture check
-- Identity with dial access to a service with by posture check
-- Identity with dial access to a service with by posture check
-- Identity with dial access to a service with by posture check
-- Identity with dial access to a service with by posture check
-- Identity with dial access to a service with by posture check
-- Identity with dial access to a service with by posture check
-- Identity with dial access to a service with by posture check
-
-
 - Identity marked as disabled, is disabled on restart of zet
 - Identity with overlapping service definitions in two different networks
-- 
 - Multiple ziti edge tunnels running at one time, intercepts are removed on clean shutdown
+- Move identity files from `%SystemRoot%\System32\config\systemprofile\AppData\Roaming\NetFoundry` to a temp folder, restart the tunnel service, and verify those identities no longer appear in the UI
 
+### Identity List Sorting
+- Sort by Name ascending and descending, verify alphabetical order
+- Sort by Status, verify enabled/disabled identities group correctly
+- Sort by Services ascending: identities needing attention (timed out, MFA needed, ext auth needed) should appear first, then by service count
+- Sort by Services descending: normal identities with the most services should appear first
+- Change sort option, restart the UI, verify the sort preference is persisted
 
 ### Adding Identities
 - by url - success
@@ -33,81 +28,95 @@ These are the tests you need to make sure to perform per release.
 - by url - url times out -- https://62a2d8fa-6ed4-4ca9-a939-db058b6696c3.production.netfoundry.io:8441/
 - by url - url is totally invalid: "this is not valid whatsoever"
 - by url - url is kinda correct: "https://google.com"
-
 - by jwt
-
 
 ### ext-jwt-signers
 - ext-jwt-signer is entirely correct
 - ext-jwt-signer incorrect, specifically the external-auth url is invalid: "this is invalid"
 - ext-jwt-signer incorrect, specifically the external-auth url never returns: https://62a2d8fa-6ed4-4ca9-a939-db058b6696c3.production.netfoundry.io:8441/
 - ext-jwt-signer incorrect, url is not the root of a .well-known/openid-configuration endpoint
-
-### Test cases
+- single ext-jwt-signer: clicking authenticate auto-launches the browser without opening identity details
 - add identity by url, turn off UI, ensure the identity needs ext auth
 - add identity by url, restart zet, ensure the identity requires ext auth
-- add identity by url, authenticate, turn off UI ensure identity does not indicate it needs auth
-- add identity by url, authenticate, restart zet, ensure the identity requires ext auth when zet start
+- add identity by url, authenticate, turn off UI, ensure identity does not indicate it needs auth
+- add identity by url, authenticate, restart zet, ensure the identity requires ext auth when zet starts
 
+### Toast Notifications
+- ext auth success while UI is minimized: toast appears with identity name
+- ext auth success while UI is active: no toast (user can see the state change)
+- ext auth failure while UI is minimized: toast appears with identity name
+- ext auth failure while UI is active: in-app blurb appears
+- start ext auth, abandon it, wait for tunnel to resend needs_ext_login: authenticate toast re-queued
+- complete ext auth, restart ZET with UI minimized: authenticate toast should appear for the identity needing re-auth
+- MFA needed while UI is minimized: toast appears with authenticate button, clicking it opens MFA screen
+- multiple identities needing authorization at startup: single summary toast with correct count instead of one per identity
+- rapidly disable/enable multiple MFA and ext auth identities with the UI minimized: after 5 seconds a single summary toast should appear with the correct count of identities requiring authorization
 
 ## Methodology
 
-- establish an `.env.ps1` file located adjacent to `scripts/setup-ids-for-test.ps1` containing:
+See [`BUILDING.md`](./BUILDING.md) for prerequisites and how to start a local quickstart network.
 
-      $ZITI_USER="usernamehere"
-      $ZITI_PASS="passwordhere"
-- execute the `.\scripts\setup-ids-for-test.ps1`:
--- ClearIdentitiesOk is a mandatory flag that must be passed. the script cleans up the specified ZitiHome directory
-   as well as cleans up the controller and resets identities, auth policies, external jwt signers etc.
--- Url is the url to the controller with or without the https
--- RouterName is the name of the router colocated with the controller. For the services to work, this router will be used
-   to offload connections back to the controller management API for verifying the service works properly.
--- ZitiHome is the location of the jwts that will be produced as well as the location for certs/keys (pki-root)
--- ExternalId is the email address of whatever user you want to use with the IdP. Likely this will be your email address
+Create a `scripts/.env.ps1` file with your controller credentials:
 
-      .\scripts\setup-ids-for-test.ps1 `
-        -ClearIdentitiesOk `
-        -Url "$zitiControllerAddress:$zitiControllerPort" `
-        -RouterName "$zitiRouterName" `
-        -ZitiHome "$pathToPlaceFiles" `
-        -ExternalId "some.email@address.com"
+```powershell
+$ZITI_USER="usernamehere"
+$ZITI_PASS="passwordhere"
+```
 
--- Example execution:
+Then run the setup script from the project root. This provisions identities, auth policies, external JWT signers, and services on the controller.
 
-      .\scripts\setup-ids-for-test.ps1 `
-        -ClearIdentitiesOk `
-        -Url "ctrl.cdaws.clint.demo.openziti.org:8441" `
-        -RouterName "ip-172-31-47-200-edge-router" `
-        -ZitiHome "C:\temp\zdew-testing\"" `
-        -ExternalId "some.email@address.com"
+- `ClearIdentitiesOk` is mandatory. The script cleans up the specified ZitiHome directory as well as the controller (resets identities, auth policies, external jwt signers, etc.)
+- `Url` is the address of the controller with or without https
+- `RouterName` is the name of the router colocated with the controller. Services use this router to offload connections back to the controller management API
+- `ZitiHome` is the directory where JWTs, certs, and keys are written
+- `ExternalId` is the email address of the user you want to use with the IdP
+
+Example using a local quickstart:
+
+```powershell
+.\scripts\setup-ids-for-test.ps1 `
+    -ClearIdentitiesOk `
+    -Url "https://localhost:1280" `
+    -RouterName "router-quickstart" `
+    -ZitiHome "C:\temp\ziti-quickstart" `
+    -ExternalId "your.email@example.com"
+```
+
+Example using a remote controller:
+
+```powershell
+.\scripts\setup-ids-for-test.ps1 `
+    -ClearIdentitiesOk `
+    -Url "ctrl.cdaws.clint.demo.openziti.org:8441" `
+    -RouterName "ip-172-31-47-200-edge-router" `
+    -ZitiHome "C:\temp\zdew-testing\" `
+    -ExternalId "your.email@example.com"
+```
 
 ## Verify MFA
 
-- Minimally, enroll the identites: 
--- mfa-not-needed.jwt
--- mfa-0.jwt
--- mfa-normal.jwt
--- mfa-to.jwt
--- mfa-unlock.jwt
--- mfa-wake.jwt
--- normal-user-01.jwt
+Minimally, enroll the following identities:
+- mfa-not-needed.jwt
+- mfa-0.jwt
+- mfa-normal.jwt
+- mfa-to.jwt
+- mfa-unlock.jwt
+- mfa-wake.jwt
+- normal-user-01.jwt
 
 ## 3rd Party CA
--- tpca-test-autoId.jwt using pki\tpca-test-autoId\certs\tpca-test-autoId-user1.cert and pki\tpca-test-autoId\keys\tpca-test-autoId-user1.key
-   with alias: `autoid01`
--- tpca-test-autoId.jwt using pki\tpca-test-autoId\certs\tpca-test-autoId-user2.cert and pki\tpca-test-autoId\keys\tpca-test-autoId-user2.key
-   with alias: `autoid02`
--- tpca-test-autoId.jwt using pki\tpca-test-autoId\certs\tpca-test-autoId-user3.cert and pki\tpca-test-autoId\keys\tpca-test-autoId-user3.key
-   with alias: `autoid03`
+- tpca-test-autoId.jwt using pki\tpca-test-autoId\certs\tpca-test-autoId-user1.cert and pki\tpca-test-autoId\keys\tpca-test-autoId-user1.key with alias: `autoid01`
+- tpca-test-autoId.jwt using pki\tpca-test-autoId\certs\tpca-test-autoId-user2.cert and pki\tpca-test-autoId\keys\tpca-test-autoId-user2.key with alias: `autoid02`
+- tpca-test-autoId.jwt using pki\tpca-test-autoId\certs\tpca-test-autoId-user3.cert and pki\tpca-test-autoId\keys\tpca-test-autoId-user3.key with alias: `autoid03`
 
-## Enable / diable
+## Enable / Disable
 
 - enable an ext-jwt-signer based identity then disable it
 - authenticate to an ext-jwt-signer then disable, enable, reauth
 - enable a cert-based auth identity then disable it, verify it auths, then disable it
 - Identity marked as enabled is enabled on restart
 - Identity marked as disabled is disabled on restart
-- get a little crazy, disable/enable a bunch of identities -  spaz out ... :)
+- get a little crazy, disable/enable a bunch of identities - spaz out ... :)
 
 ## Random
 

--- a/manual-testing.md
+++ b/manual-testing.md
@@ -35,7 +35,7 @@ These are the tests you need to make sure to perform per release.
 - ext-jwt-signer incorrect, specifically the external-auth url is invalid: "this is invalid"
 - ext-jwt-signer incorrect, specifically the external-auth url never returns: https://62a2d8fa-6ed4-4ca9-a939-db058b6696c3.production.netfoundry.io:8441/
 - ext-jwt-signer incorrect, url is not the root of a .well-known/openid-configuration endpoint
-- single ext-jwt-signer: clicking authenticate auto-launches the browser without opening identity details
+- single ext-jwt-signer: clicking authenticate on the toast notification auto-launches the browser without opening identity details
 - add identity by url, turn off UI, ensure the identity needs ext auth
 - add identity by url, restart zet, ensure the identity requires ext auth
 - add identity by url, authenticate, turn off UI, ensure identity does not indicate it needs auth

--- a/upcoming-release-notes.md
+++ b/upcoming-release-notes.md
@@ -1,6 +1,6 @@
-# Release 2.10.3.0
+# Next Release
 ## What's New
-n/a
+* [Issue 970](https://github.com/openziti/desktop-edge-win/issues/970) - Added toast notifications for external auth success/failure when the UI is minimized and auto-launch browser for single-provider external auth
 
 ## Bugs fixed
 * [Issue 960](https://github.com/openziti/desktop-edge-win/issues/960) - Fixed forget identity confirmation modal not consistently filling the full UI area


### PR DESCRIPTION
- When clicking the "authenticate" toast button with only one ext auth provider, automatically launch the browser instead of opening the identity details page
- Show success/failure toast notifications for external auth when the UI is minimized; fall back to in-app blurb when the UI is active for failure - external auth success is pretty obvious if the UI is active
- Rework the identity event state machine so `needs_ext_login` clears `AuthInProgress`, and the subsequent `added` event detects auth completion

Resolves #970

** waiting on https://github.com/openziti/ziti-sdk-c/pull/1027 and a tunnel fix for external auth errors