### PR TITLE
Add update progress UI and failure handling

### DIFF
--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -948,13 +948,13 @@ namespace ZitiDesktopEdge {
         private void MonitorClient_OnServiceStatusEvent(object sender, MonitorServiceStatusEvent evt) {
             this.Dispatcher.Invoke(() => {
                 try {
-                    if (evt.Message != null && evt.Message.StartsWith("UpdateProgress:")) {
+                    if (evt.Message?.StartsWith("UpdateProgress:") == true) {
                         string phase = evt.Message.Substring("UpdateProgress:".Length);
                         logger.Info("Upgrade progress phase received: {0}", phase);
                         ShowLoad("Update In Progress", phase);
                         return;
                     }
-                    if (evt.Message != null && evt.Message.StartsWith("UpdateFailed:")) {
+                    if (evt.Message?.StartsWith("UpdateFailed:") == true) {
                         string reason = evt.Message.Substring("UpdateFailed:".Length);
                         logger.Warn("Update failed: {0}", reason);
                         UpgradeSentinel.StopUpgradeSentinel();

--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -948,9 +948,15 @@ namespace ZitiDesktopEdge {
         private void MonitorClient_OnServiceStatusEvent(object sender, MonitorServiceStatusEvent evt) {
             this.Dispatcher.Invoke(() => {
                 try {
+                    if (evt.Message != null && evt.Message.StartsWith("UpdateProgress:")) {
+                        string phase = evt.Message.Substring("UpdateProgress:".Length);
+                        logger.Info("Upgrade progress phase received: {0}", phase);
+                        ShowLoad("Update In Progress", phase);
+                        return;
+                    }
                     if (evt.Message?.ToLower() == "upgrading") {
                         logger.Info("The monitor has indicated an upgrade is in progress. Shutting down the UI");
-                        UpgradeSentinel.StartUpgradeSentinel();
+                        UpgradeSentinel.StartUpgradeSentinel(false);
 
                         App.Current.Exit -= Current_Exit;
                         logger.Info("Removed Current_Exit handler");
@@ -1009,6 +1015,9 @@ namespace ZitiDesktopEdge {
         }
 
         private void SetAutomaticUpdateEnabled(string enabled, string url) {
+            if (enabled == null) {
+                return;
+            }
             try {
                 bool yn = bool.Parse(enabled);
                 state.AutomaticUpdatesDisabled = yn;

--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -954,6 +954,16 @@ namespace ZitiDesktopEdge {
                         ShowLoad("Update In Progress", phase);
                         return;
                     }
+                    if (evt.Message != null && evt.Message.StartsWith("UpdateFailed:")) {
+                        string reason = evt.Message.Substring("UpdateFailed:".Length);
+                        logger.Warn("Update failed: {0}", reason);
+                        UpgradeSentinel.StopUpgradeSentinel();
+                        HideLoad();
+                        this.Show();
+                        this.Activate();
+                        ShowError("Update Failed", reason);
+                        return;
+                    }
                     if (evt.Message?.ToLower() == "upgrading") {
                         logger.Info("The monitor has indicated an upgrade is in progress. Shutting down the UI");
                         UpgradeSentinel.StartUpgradeSentinel(false);

--- a/DesktopEdge/Views/Screens/MainMenu.xaml.cs
+++ b/DesktopEdge/Views/Screens/MainMenu.xaml.cs
@@ -483,7 +483,6 @@ namespace ZitiDesktopEdge {
             this.UpdateUrl.Text = state.AutomaticUpdateURL;
         }
 
-
         async private void CheckForUpdate_OnClick(object sender, MouseButtonEventArgs e) {
             logger.Info("checking for update...");
             CheckForUpdateStatus.Content = "Checking for updates...";

--- a/DesktopEdge/Views/Screens/MainMenu.xaml.cs
+++ b/DesktopEdge/Views/Screens/MainMenu.xaml.cs
@@ -483,6 +483,7 @@ namespace ZitiDesktopEdge {
             this.UpdateUrl.Text = state.AutomaticUpdateURL;
         }
 
+
         async private void CheckForUpdate_OnClick(object sender, MouseButtonEventArgs e) {
             logger.Info("checking for update...");
             CheckForUpdateStatus.Content = "Checking for updates...";
@@ -521,7 +522,7 @@ namespace ZitiDesktopEdge {
             try {
                 CheckForUpdateStatus.Content = "Requesting automatic update...";
                 var monitorClient = (MonitorClient)Application.Current.Properties["MonitorClient"];
-                var r = await monitorClient.TriggerUpdate();
+                SvcResponse r = await monitorClient.TriggerUpdate();
                 CheckForUpdateStatus.Content = "Automatic update requested...";
                 if (r == null) {
                     MainWindow.ShowError("Error When Triggering Update", "An error occurred while trying to trigger the update.");

--- a/ZitiDesktopEdge.Client/ServiceClient/MonitorClient.cs
+++ b/ZitiDesktopEdge.Client/ServiceClient/MonitorClient.cs
@@ -164,7 +164,7 @@ namespace ZitiDesktopEdge.ServiceClient {
         }
 
         async public Task<SvcResponse> TriggerUpdate() {
-            UpgradeSentinel.StartUpgradeSentinel();
+            UpgradeSentinel.StartUpgradeSentinel(true);
             ActionEvent action = new ActionEvent() { Op = "TriggerUpdate", Action = "" };
             await sendMonitorClientAsync(action);
             return await readMonitorClientAsync<SvcResponse>(ipcReader);

--- a/ZitiDesktopEdge.Client/Utility/UpgradeSentinel.cs
+++ b/ZitiDesktopEdge.Client/Utility/UpgradeSentinel.cs
@@ -30,7 +30,7 @@ namespace ZitiDesktopEdge.Utility {
         public const string ZitiUpgradeSentinelExeName = "ZitiUpgradeSentinel.exe";
         private static string SentinelTempSource = Path.Combine(Path.GetTempPath(), ZitiUpgradeSentinelExeName);
 
-        public static void StartUpgradeSentinel() {
+        public static void StartUpgradeSentinel(bool showProgress) {
             //start the sentinel process...
             using (Process process = new Process()) {
                 string executablePath = Assembly.GetEntryAssembly().Location;
@@ -42,7 +42,8 @@ namespace ZitiDesktopEdge.Utility {
                         File.Copy(sentinelSource, SentinelTempSource, true);
                         logger.Info("starting sentinel process: {}", SentinelTempSource);
                         process.StartInfo.FileName = SentinelTempSource;
-                        process.StartInfo.Arguments = "version";
+                        string args = showProgress ? "version --show-progress" : "version";
+                        process.StartInfo.Arguments = args;
                         process.StartInfo.RedirectStandardOutput = true;
                         process.StartInfo.UseShellExecute = false;
                         process.StartInfo.CreateNoWindow = true;

--- a/ZitiDesktopEdge.Client/Utility/UpgradeSentinel.cs
+++ b/ZitiDesktopEdge.Client/Utility/UpgradeSentinel.cs
@@ -66,15 +66,15 @@ namespace ZitiDesktopEdge.Utility {
         }
 
         public static void StopUpgradeSentinel() {
-            try {
-                Process[] sentinels = Process.GetProcessesByName("ZitiUpgradeSentinel");
-                foreach (Process sentinel in sentinels) {
+            Process[] sentinels = Process.GetProcessesByName("ZitiUpgradeSentinel");
+            foreach (Process sentinel in sentinels) {
+                try {
                     logger.Info("killing upgrade sentinel process: {}", sentinel.Id);
                     sentinel.Kill();
                     sentinel.Dispose();
+                } catch (Exception ex) {
+                    logger.Error("failed to stop upgrade sentinel: {}", ex.Message);
                 }
-            } catch (Exception ex) {
-                logger.Error("failed to stop upgrade sentinel: {}", ex.Message);
             }
         }
 

--- a/ZitiDesktopEdge.Client/Utility/UpgradeSentinel.cs
+++ b/ZitiDesktopEdge.Client/Utility/UpgradeSentinel.cs
@@ -65,6 +65,19 @@ namespace ZitiDesktopEdge.Utility {
             }
         }
 
+        public static void StopUpgradeSentinel() {
+            try {
+                Process[] sentinels = Process.GetProcessesByName("ZitiUpgradeSentinel");
+                foreach (Process sentinel in sentinels) {
+                    logger.Info("killing upgrade sentinel process: {}", sentinel.Id);
+                    sentinel.Kill();
+                    sentinel.Dispose();
+                }
+            } catch (Exception ex) {
+                logger.Error("failed to stop upgrade sentinel: {}", ex.Message);
+            }
+        }
+
         public static void RemoveUpgradeSentinelExe() {
             try {
                 if (File.Exists(SentinelTempSource)) {

--- a/ZitiDesktopEdge.Client/Utility/UpgradeSentinel.cs
+++ b/ZitiDesktopEdge.Client/Utility/UpgradeSentinel.cs
@@ -30,19 +30,27 @@ namespace ZitiDesktopEdge.Utility {
         public const string ZitiUpgradeSentinelExeName = "ZitiUpgradeSentinel.exe";
         private static string SentinelTempSource = Path.Combine(Path.GetTempPath(), ZitiUpgradeSentinelExeName);
 
+        private static string PrefsDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "NetFoundry");
+        private static string HideProgressFile = Path.Combine(PrefsDirectory, "hide-upgrade-progress");
+
+        public static bool IsProgressHidden() {
+            return File.Exists(HideProgressFile);
+        }
+
         public static void StartUpgradeSentinel(bool showProgress) {
             //start the sentinel process...
             using (Process process = new Process()) {
                 string executablePath = Assembly.GetEntryAssembly().Location;
                 string executableDirectory = Path.GetDirectoryName(executablePath);
-                var sentinelSource = Path.Combine(executableDirectory, ZitiUpgradeSentinelExeName);
+                string sentinelSource = Path.Combine(executableDirectory, ZitiUpgradeSentinelExeName);
 
                 if (File.Exists(sentinelSource)) {
                     try {
                         File.Copy(sentinelSource, SentinelTempSource, true);
                         logger.Info("starting sentinel process: {}", SentinelTempSource);
                         process.StartInfo.FileName = SentinelTempSource;
-                        string args = showProgress ? "version --show-progress" : "version";
+                        bool shouldShow = showProgress && !IsProgressHidden();
+                        string args = shouldShow ? "version --show-progress" : "version";
                         process.StartInfo.Arguments = args;
                         process.StartInfo.RedirectStandardOutput = true;
                         process.StartInfo.UseShellExecute = false;
@@ -60,7 +68,6 @@ namespace ZitiDesktopEdge.Utility {
         public static void RemoveUpgradeSentinelExe() {
             try {
                 if (File.Exists(SentinelTempSource)) {
-                    // if the temp file exists, clear it out
                     File.Delete(SentinelTempSource);
                     logger.Debug("found and removed upgrade sentinel at: {}", SentinelTempSource);
                 } else {

--- a/ZitiUpdateService/UpdateService.cs
+++ b/ZitiUpdateService/UpdateService.cs
@@ -803,12 +803,23 @@ namespace ZitiUpdateService {
             semaphore.Release();
         }
 
+        private void SendUpgradeProgress(string phase) {
+            var status = new MonitorServiceStatusEvent() {
+                Code = 0,
+                Error = "",
+                Message = "UpdateProgress:" + phase,
+                Status = ServiceActions.ServiceStatus(),
+            };
+            EventRegistry.SendEventToConsumers(status);
+        }
+
         private void installZDE(UpdateCheck check) {
             string fileDestination = Path.Combine(updateFolder, check?.FileName);
 
             if (check.AlreadyDownloaded(updateFolder, check.FileName)) {
                 Logger.Trace("package has already been downloaded to {0}", fileDestination);
             } else {
+                SendUpgradeProgress("Updating");
                 Logger.Info("copying update package begins");
                 try {
                     check.CopyUpdatePackage(updateFolder, check.FileName);
@@ -833,6 +844,7 @@ namespace ZitiUpdateService {
 				new SignedFileValidator(fileDestination).Verify();
 				Logger.Info("SignedFileValidator complete");
 
+				SendUpgradeProgress("Installing");
 				StopZiti();
 				StopUI().Wait();
 

--- a/ZitiUpdateService/UpdateService.cs
+++ b/ZitiUpdateService/UpdateService.cs
@@ -804,23 +804,23 @@ namespace ZitiUpdateService {
         }
 
         private void SendUpgradeProgress(string phase) {
-            var status = new MonitorServiceStatusEvent() {
+            MonitorServiceStatusEvent progressEvent = new MonitorServiceStatusEvent() {
                 Code = 0,
                 Error = "",
                 Message = "UpdateProgress:" + phase,
                 Status = ServiceActions.ServiceStatus(),
             };
-            EventRegistry.SendEventToConsumers(status);
+            EventRegistry.SendEventToConsumers(progressEvent);
         }
 
         private void SendUpgradeFailure(string reason) {
-            var status = new MonitorServiceStatusEvent() {
+            MonitorServiceStatusEvent failureEvent = new MonitorServiceStatusEvent() {
                 Code = 1,
                 Error = reason,
                 Message = "UpdateFailed:" + reason,
                 Status = ServiceActions.ServiceStatus(),
             };
-            EventRegistry.SendEventToConsumers(status);
+            EventRegistry.SendEventToConsumers(failureEvent);
         }
 
         private void installZDE(UpdateCheck check) {
@@ -829,7 +829,7 @@ namespace ZitiUpdateService {
             if (check.AlreadyDownloaded(updateFolder, check.FileName)) {
                 Logger.Trace("package has already been downloaded to {0}", fileDestination);
             } else {
-                SendUpgradeProgress("Updating");
+                SendUpgradeProgress("Downloading");
                 Logger.Info("copying update package begins");
                 try {
                     check.CopyUpdatePackage(updateFolder, check.FileName);
@@ -842,6 +842,7 @@ namespace ZitiUpdateService {
             }
 
             Logger.Info("package is in {0} - moving to install phase", fileDestination);
+            SendUpgradeProgress("Verifying");
 
             if (!check.HashIsValid(updateFolder, check.FileName)) {
                 Logger.Warn("The file was downloaded but the hash is not valid. The file will be removed: {0}", fileDestination);

--- a/ZitiUpdateService/UpdateService.cs
+++ b/ZitiUpdateService/UpdateService.cs
@@ -813,6 +813,16 @@ namespace ZitiUpdateService {
             EventRegistry.SendEventToConsumers(status);
         }
 
+        private void SendUpgradeFailure(string reason) {
+            var status = new MonitorServiceStatusEvent() {
+                Code = 1,
+                Error = reason,
+                Message = "UpdateFailed:" + reason,
+                Status = ServiceActions.ServiceStatus(),
+            };
+            EventRegistry.SendEventToConsumers(status);
+        }
+
         private void installZDE(UpdateCheck check) {
             string fileDestination = Path.Combine(updateFolder, check?.FileName);
 
@@ -825,6 +835,7 @@ namespace ZitiUpdateService {
                     check.CopyUpdatePackage(updateFolder, check.FileName);
                 } catch (Exception e) {
                     Logger.Error("copying update package failed! {0}", e);
+                    SendUpgradeFailure("Download failed");
                     return;
                 }
                 Logger.Info("copying update package complete");
@@ -835,6 +846,7 @@ namespace ZitiUpdateService {
             if (!check.HashIsValid(updateFolder, check.FileName)) {
                 Logger.Warn("The file was downloaded but the hash is not valid. The file will be removed: {0}", fileDestination);
                 File.Delete(fileDestination);
+                SendUpgradeFailure("Hash verification failed");
                 return;
             }
             Logger.Debug("downloaded file hash was correct. update can continue.");
@@ -853,6 +865,7 @@ namespace ZitiUpdateService {
 				Process.Start(fileDestination, "/passive");
 			} catch (Exception ex) {
 				Logger.Error(ex, "Unexpected error during installation");
+				SendUpgradeFailure("Installation failed");
 			}
 #else
             Logger.Warn("SKIPUPDATE IS SET - NOT PERFORMING UPDATE of version: {} published at {}", check.GetNextVersion(), check.PublishDate);

--- a/ZitiUpgradeSentinel/Program.cs
+++ b/ZitiUpgradeSentinel/Program.cs
@@ -19,7 +19,6 @@ using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.IO.Pipes;
-using System.ServiceProcess;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
@@ -58,7 +57,6 @@ class FileWatcher {
                     try {
                         await RunWithTimeout(task: WaitForStartupChange(), timeout: TimeSpan.FromMinutes(5));
                         UpdateStatus("Launching application...");
-                        Thread.Sleep(500);
                         StartZitiDesktopEdgeUI();
                     } catch (Exception e) {
                         Log($"{processName} completed exceptionally: {e}");
@@ -70,8 +68,10 @@ class FileWatcher {
 
                 Application.Run(progressForm);
             } else {
-                RunWithTimeout(task: WaitForStartupChange(), timeout: TimeSpan.FromMinutes(5)).Wait();
-                StartZitiDesktopEdgeUI();
+                Task.Run(async () => {
+                    await RunWithTimeout(task: WaitForStartupChange(), timeout: TimeSpan.FromMinutes(5));
+                    StartZitiDesktopEdgeUI();
+                }).Wait();
             }
         } catch (Exception e) {
             Log($"{processName} completed exceptionally: {e}");
@@ -80,10 +80,26 @@ class FileWatcher {
         }
     }
 
+    private static string prefsDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "NetFoundry");
+    private static string hideProgressFile = Path.Combine(prefsDirectory, "hide-upgrade-progress");
+
+    private static void SaveHidePreference(bool hide) {
+        try {
+            if (hide) {
+                Directory.CreateDirectory(prefsDirectory);
+                File.WriteAllText(hideProgressFile, "");
+            } else if (File.Exists(hideProgressFile)) {
+                File.Delete(hideProgressFile);
+            }
+        } catch (Exception ex) {
+            Log($"Failed to save preference: {ex.Message}");
+        }
+    }
+
     private static Form CreateProgressForm() {
-        var form = new Form {
+        Form form = new Form {
             Text = "Ziti Desktop Edge - Updating",
-            Size = new Size(420, 130),
+            Size = new Size(420, 160),
             FormBorderStyle = FormBorderStyle.FixedDialog,
             StartPosition = FormStartPosition.CenterScreen,
             MaximizeBox = false,
@@ -95,10 +111,12 @@ class FileWatcher {
         try {
             string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             form.Icon = Icon.ExtractAssociatedIcon(exePath);
-        } catch { }
+        } catch (Exception ex) {
+            Log($"Failed to extract icon: {ex.Message}");
+        }
 
         statusLabel = new Label {
-            Text = "Update in progress...",
+            Text = "Launching installer...",
             AutoSize = false,
             TextAlign = ContentAlignment.MiddleCenter,
             Dock = DockStyle.Top,
@@ -106,15 +124,25 @@ class FileWatcher {
             Font = new Font("Segoe UI", 11f),
         };
 
-        var progressBar = new ProgressBar {
+        ProgressBar progressBar = new ProgressBar {
             Style = ProgressBarStyle.Marquee,
             MarqueeAnimationSpeed = 30,
             Dock = DockStyle.Top,
             Height = 25,
         };
 
-        var padding = new Panel { Dock = DockStyle.Top, Height = 10 };
+        CheckBox hideCheckbox = new CheckBox {
+            Text = "Don't show this again",
+            Dock = DockStyle.Bottom,
+            Height = 25,
+            Font = new Font("Segoe UI", 9f),
+            Padding = new Padding(5, 0, 0, 0),
+        };
+        hideCheckbox.CheckedChanged += (sender, e) => SaveHidePreference(hideCheckbox.Checked);
 
+        Panel padding = new Panel { Dock = DockStyle.Top, Height = 10 };
+
+        form.Controls.Add(hideCheckbox);
         form.Controls.Add(progressBar);
         form.Controls.Add(padding);
         form.Controls.Add(statusLabel);
@@ -156,30 +184,27 @@ class FileWatcher {
         DateTime startTime = DateTime.Parse(response.Data.StartTime).ToLocalTime();
         Log($"StartTime: {startTime}");
         return startTime;
-        throw new Exception("could not obtain current time from data service");
-    }
-
-    private static bool IsServiceRunning(string serviceName) {
-        try {
-            ServiceController sc = new ServiceController(serviceName);
-            sc.Refresh();
-            return sc.Status == ServiceControllerStatus.Running;
-        } catch {
-            return false;
-        }
     }
 
     public static async Task WaitForStartupChange() {
-        DateTime startTime = DateTime.Now;
+        DateTime sentinelLaunchTime = DateTime.Now;
+        DateTime startTime = sentinelLaunchTime;
         try {
             using (NamedPipeClientStream pipeClient = new NamedPipeClientStream(".", "ziti-edge-tunnel.sock", PipeDirection.InOut)) {
-                pipeClient.Connect();
+                pipeClient.Connect(5000);
                 StreamWriter writer = new StreamWriter(pipeClient);
                 StreamReader reader = new StreamReader(pipeClient);
 
                 try {
                     startTime = GetCurrentStartTime(writer, reader);
                     Log($"initial start time {startTime}");
+
+                    // If the service started after the sentinel launched, the
+                    // update already completed before we got here.
+                    if (startTime > sentinelLaunchTime) {
+                        Log($"Service already restarted (start time {startTime} is after sentinel launch {sentinelLaunchTime})");
+                        return;
+                    }
                 } catch {
                     Log("Could not obtain current time. The service is expected to be down. Using 'now' as current time.");
                 }
@@ -188,39 +213,11 @@ class FileWatcher {
             Log($"Error: {ex.Message}");
         }
 
-        // Wait for ziti service to stop
-        UpdateStatus("Stopping ziti service...");
-        while (IsServiceRunning("ziti")) {
-            await Task.Delay(500);
-        }
-
-        // Wait for ziti-monitor to stop
-        UpdateStatus("Stopping ziti-monitor service...");
-        while (IsServiceRunning("ziti-monitor")) {
-            await Task.Delay(500);
-        }
-
-        // Wait for services to come back
-        UpdateStatus("Installing update...");
-        while (!IsServiceRunning("ziti") && !IsServiceRunning("ziti-monitor")) {
-            await Task.Delay(500);
-        }
-
-        UpdateStatus("Starting ziti service...");
-        while (!IsServiceRunning("ziti")) {
-            await Task.Delay(500);
-        }
-
-        UpdateStatus("Starting ziti-monitor service...");
-        while (!IsServiceRunning("ziti-monitor")) {
-            await Task.Delay(500);
-        }
-
-        // Verify tunnel actually restarted via pipe
+        UpdateStatus("Waiting for services to stop...");
         while (true) {
             try {
                 using (NamedPipeClientStream pipeClient = new NamedPipeClientStream(".", "ziti-edge-tunnel.sock", PipeDirection.InOut)) {
-                    pipeClient.Connect();
+                    pipeClient.Connect(2000);
                     StreamWriter writer = new StreamWriter(pipeClient);
                     StreamReader reader = new StreamReader(pipeClient);
                     DateTime nextStartTime = GetCurrentStartTime(writer, reader);
@@ -228,8 +225,10 @@ class FileWatcher {
                         Log($"{startTime} has changed to {nextStartTime}");
                         return;
                     }
+                    UpdateStatus("Waiting for services to stop...");
                 }
             } catch (Exception ex) {
+                UpdateStatus("Waiting for services to start...");
                 Log($"Error: {ex.Message}");
             }
             await Task.Delay(500);

--- a/ZitiUpgradeSentinel/Program.cs
+++ b/ZitiUpgradeSentinel/Program.cs
@@ -61,11 +61,11 @@ class FileWatcher {
                     } catch (TimeoutException) {
                         Log($"{processName} timed out waiting for service restart");
                         UpdateStatus($"Update timed out. Please restart manually.\nSee log: {logFilePath}");
-                        Thread.Sleep(5000);
+                        await Task.Delay(5000);
                     } catch (Exception e) {
                         Log($"{processName} completed exceptionally: {e}");
                         UpdateStatus($"Update failed. Please restart manually.\nSee log: {logFilePath}");
-                        Thread.Sleep(5000);
+                        await Task.Delay(5000);
                     } finally {
                         Log($"{processName} completed");
                         CloseForm();
@@ -197,8 +197,7 @@ class FileWatcher {
     }
 
     public static async Task WaitForStartupChange() {
-        DateTime sentinelLaunchTime = DateTime.Now;
-        DateTime startTime = sentinelLaunchTime;
+        DateTime startTime = DateTime.Now;
         try {
             using (NamedPipeClientStream pipeClient = new NamedPipeClientStream(".", "ziti-edge-tunnel.sock", PipeDirection.InOut)) {
                 pipeClient.Connect(5000);
@@ -208,13 +207,6 @@ class FileWatcher {
                 try {
                     startTime = GetCurrentStartTime(writer, reader);
                     Log($"initial start time {startTime}");
-
-                    // If the service started after the sentinel launched, the
-                    // update already completed before we got here.
-                    if (startTime > sentinelLaunchTime) {
-                        Log($"Service already restarted (start time {startTime} is after sentinel launch {sentinelLaunchTime})");
-                        return;
-                    }
                 } catch {
                     Log("Could not obtain current time. The service is expected to be down. Using 'now' as current time.");
                 }
@@ -251,7 +243,7 @@ class FileWatcher {
                 cancellationTokenSource.Cancel();
                 await task;
             } else {
-                throw new System.TimeoutException("The operation has timed out.");
+                throw new TimeoutException("The operation has timed out.");
             }
         }
     }

--- a/ZitiUpgradeSentinel/Program.cs
+++ b/ZitiUpgradeSentinel/Program.cs
@@ -109,7 +109,7 @@ class FileWatcher {
     private static Form CreateProgressForm() {
         Form form = new Form {
             Text = "Ziti Desktop Edge - Updating",
-            Size = new Size(420, 160),
+            Size = new Size(360, 140),
             FormBorderStyle = FormBorderStyle.FixedDialog,
             StartPosition = FormStartPosition.CenterScreen,
             MaximizeBox = false,
@@ -130,27 +130,27 @@ class FileWatcher {
             AutoSize = false,
             TextAlign = ContentAlignment.MiddleCenter,
             Dock = DockStyle.Top,
-            Height = 50,
-            Font = new Font("Segoe UI", 11f),
+            Height = 40,
+            Font = new Font("Segoe UI", 10f),
         };
 
         ProgressBar progressBar = new ProgressBar {
             Style = ProgressBarStyle.Marquee,
             MarqueeAnimationSpeed = 30,
             Dock = DockStyle.Top,
-            Height = 25,
+            Height = 20,
         };
 
         CheckBox hideCheckbox = new CheckBox {
             Text = "Don't show this again",
             Dock = DockStyle.Bottom,
-            Height = 25,
+            Height = 20,
             Font = new Font("Segoe UI", 9f),
             Padding = new Padding(5, 0, 0, 0),
         };
         hideCheckbox.CheckedChanged += (sender, e) => SaveHidePreference(hideCheckbox.Checked);
 
-        Panel padding = new Panel { Dock = DockStyle.Top, Height = 10 };
+        Panel padding = new Panel { Dock = DockStyle.Top, Height = 6 };
 
         form.Controls.Add(hideCheckbox);
         form.Controls.Add(progressBar);

--- a/ZitiUpgradeSentinel/Program.cs
+++ b/ZitiUpgradeSentinel/Program.cs
@@ -16,14 +16,17 @@
 
 using System;
 using System.Diagnostics;
+using System.Drawing;
 using System.IO;
 using System.IO.Pipes;
+using System.ServiceProcess;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Json;
 using System.Text;
+using System.Windows.Forms;
 
 class FileWatcher {
     private static string processName = Process.GetCurrentProcess().ProcessName;
@@ -31,20 +34,113 @@ class FileWatcher {
     private static string fileName = $"{processName}_{DateTime.Now:yyyyMMddHHmmss}.log";
     private static string logFilePath = Path.Combine(tempDir, fileName);
 
-    public static async Task Main(string[] args) {
-        Log($"{processName} started");
+    private static Form progressForm;
+    private static Label statusLabel;
+    private static bool showProgress = false;
+
+    [STAThread]
+    public static void Main(string[] args) {
+        showProgress = Array.Exists(args, a => a == "--show-progress");
+        Log($"{processName} started. showProgress={showProgress}");
+
         try {
             if (Process.GetProcessesByName(processName).Length > 1) {
                 Log("Another instance is already running. Exiting...");
                 return;
             }
-            await RunWithTimeout(task: WaitForStartupChange(), timeout: TimeSpan.FromMinutes(5));
-            StartZitiDesktopEdgeUI();
+
+            if (showProgress) {
+                Application.EnableVisualStyles();
+                Application.SetCompatibleTextRenderingDefault(false);
+                progressForm = CreateProgressForm();
+
+                Task.Run(async () => {
+                    try {
+                        await RunWithTimeout(task: WaitForStartupChange(), timeout: TimeSpan.FromMinutes(5));
+                        UpdateStatus("Launching application...");
+                        Thread.Sleep(500);
+                        StartZitiDesktopEdgeUI();
+                    } catch (Exception e) {
+                        Log($"{processName} completed exceptionally: {e}");
+                    } finally {
+                        Log($"{processName} completed");
+                        CloseForm();
+                    }
+                });
+
+                Application.Run(progressForm);
+            } else {
+                RunWithTimeout(task: WaitForStartupChange(), timeout: TimeSpan.FromMinutes(5)).Wait();
+                StartZitiDesktopEdgeUI();
+            }
         } catch (Exception e) {
-            Log($"{processName} completed exceptionally: ");
-            Log(e.ToString());
+            Log($"{processName} completed exceptionally: {e}");
         } finally {
             Log($"{processName} completed");
+        }
+    }
+
+    private static Form CreateProgressForm() {
+        var form = new Form {
+            Text = "Ziti Desktop Edge - Updating",
+            Size = new Size(420, 130),
+            FormBorderStyle = FormBorderStyle.FixedDialog,
+            StartPosition = FormStartPosition.CenterScreen,
+            MaximizeBox = false,
+            MinimizeBox = false,
+            TopMost = true,
+            ShowInTaskbar = true,
+        };
+
+        try {
+            string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
+            form.Icon = Icon.ExtractAssociatedIcon(exePath);
+        } catch { }
+
+        statusLabel = new Label {
+            Text = "Update in progress...",
+            AutoSize = false,
+            TextAlign = ContentAlignment.MiddleCenter,
+            Dock = DockStyle.Top,
+            Height = 50,
+            Font = new Font("Segoe UI", 11f),
+        };
+
+        var progressBar = new ProgressBar {
+            Style = ProgressBarStyle.Marquee,
+            MarqueeAnimationSpeed = 30,
+            Dock = DockStyle.Top,
+            Height = 25,
+        };
+
+        var padding = new Panel { Dock = DockStyle.Top, Height = 10 };
+
+        form.Controls.Add(progressBar);
+        form.Controls.Add(padding);
+        form.Controls.Add(statusLabel);
+
+        return form;
+    }
+
+    private static void UpdateStatus(string text) {
+        Log($"Status: {text}");
+        if (!showProgress || progressForm == null || progressForm.IsDisposed) {
+            return;
+        }
+        if (progressForm.InvokeRequired) {
+            progressForm.Invoke(new Action(() => statusLabel.Text = text));
+        } else {
+            statusLabel.Text = text;
+        }
+    }
+
+    private static void CloseForm() {
+        if (progressForm != null && !progressForm.IsDisposed) {
+            if (progressForm.InvokeRequired) {
+                progressForm.Invoke(new Action(() => progressForm.Close()));
+            } else {
+                progressForm.Close();
+            }
         }
     }
 
@@ -61,6 +157,16 @@ class FileWatcher {
         Log($"StartTime: {startTime}");
         return startTime;
         throw new Exception("could not obtain current time from data service");
+    }
+
+    private static bool IsServiceRunning(string serviceName) {
+        try {
+            ServiceController sc = new ServiceController(serviceName);
+            sc.Refresh();
+            return sc.Status == ServiceControllerStatus.Running;
+        } catch {
+            return false;
+        }
     }
 
     public static async Task WaitForStartupChange() {
@@ -82,6 +188,35 @@ class FileWatcher {
             Log($"Error: {ex.Message}");
         }
 
+        // Wait for ziti service to stop
+        UpdateStatus("Stopping ziti service...");
+        while (IsServiceRunning("ziti")) {
+            await Task.Delay(500);
+        }
+
+        // Wait for ziti-monitor to stop
+        UpdateStatus("Stopping ziti-monitor service...");
+        while (IsServiceRunning("ziti-monitor")) {
+            await Task.Delay(500);
+        }
+
+        // Wait for services to come back
+        UpdateStatus("Installing update...");
+        while (!IsServiceRunning("ziti") && !IsServiceRunning("ziti-monitor")) {
+            await Task.Delay(500);
+        }
+
+        UpdateStatus("Starting ziti service...");
+        while (!IsServiceRunning("ziti")) {
+            await Task.Delay(500);
+        }
+
+        UpdateStatus("Starting ziti-monitor service...");
+        while (!IsServiceRunning("ziti-monitor")) {
+            await Task.Delay(500);
+        }
+
+        // Verify tunnel actually restarted via pipe
         while (true) {
             try {
                 using (NamedPipeClientStream pipeClient = new NamedPipeClientStream(".", "ziti-edge-tunnel.sock", PipeDirection.InOut)) {
@@ -89,18 +224,15 @@ class FileWatcher {
                     StreamWriter writer = new StreamWriter(pipeClient);
                     StreamReader reader = new StreamReader(pipeClient);
                     DateTime nextStartTime = GetCurrentStartTime(writer, reader);
-                    if (startTime == nextStartTime) {
-                        Log($"{startTime} is equal to {nextStartTime}");
-                    } else {
+                    if (nextStartTime != startTime) {
                         Log($"{startTime} has changed to {nextStartTime}");
                         return;
                     }
-                    await Task.Delay(TimeSpan.FromMilliseconds(500)); // wait for the serice to start and return a result
                 }
             } catch (Exception ex) {
                 Log($"Error: {ex.Message}");
             }
-            await Task.Delay(TimeSpan.FromMilliseconds(500)); // try again...
+            await Task.Delay(500);
         }
     }
 
@@ -110,10 +242,11 @@ class FileWatcher {
                 cancellationTokenSource.Cancel();
                 await task;
             } else {
-                throw new TimeoutException("The operation has timed out.");
+                throw new System.TimeoutException("The operation has timed out.");
             }
         }
     }
+
     public static void Log(string message) {
         Console.WriteLine(message);
         File.AppendAllText(logFilePath, $"{DateTime.Now:yyyy-MM-dd HH:mm:ss} - {message}\n");

--- a/ZitiUpgradeSentinel/Program.cs
+++ b/ZitiUpgradeSentinel/Program.cs
@@ -58,8 +58,14 @@ class FileWatcher {
                         await RunWithTimeout(task: WaitForStartupChange(), timeout: TimeSpan.FromMinutes(5));
                         UpdateStatus("Launching application...");
                         StartZitiDesktopEdgeUI();
+                    } catch (TimeoutException) {
+                        Log($"{processName} timed out waiting for service restart");
+                        UpdateStatus($"Update timed out. Please restart manually.\nSee log: {logFilePath}");
+                        Thread.Sleep(5000);
                     } catch (Exception e) {
                         Log($"{processName} completed exceptionally: {e}");
+                        UpdateStatus($"Update failed. Please restart manually.\nSee log: {logFilePath}");
+                        Thread.Sleep(5000);
                     } finally {
                         Log($"{processName} completed");
                         CloseForm();
@@ -69,8 +75,12 @@ class FileWatcher {
                 Application.Run(progressForm);
             } else {
                 Task.Run(async () => {
-                    await RunWithTimeout(task: WaitForStartupChange(), timeout: TimeSpan.FromMinutes(5));
-                    StartZitiDesktopEdgeUI();
+                    try {
+                        await RunWithTimeout(task: WaitForStartupChange(), timeout: TimeSpan.FromMinutes(5));
+                        StartZitiDesktopEdgeUI();
+                    } catch (TimeoutException) {
+                        Log($"{processName} timed out waiting for service restart");
+                    }
                 }).Wait();
             }
         } catch (Exception e) {

--- a/ZitiUpgradeSentinel/ZitiUpgradeSentinel.csproj
+++ b/ZitiUpgradeSentinel/ZitiUpgradeSentinel.csproj
@@ -41,7 +41,6 @@
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/ZitiUpgradeSentinel/ZitiUpgradeSentinel.csproj
+++ b/ZitiUpgradeSentinel/ZitiUpgradeSentinel.csproj
@@ -41,6 +41,9 @@
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ServiceProcess" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
     </Reference>

--- a/upcoming-release-notes.md
+++ b/upcoming-release-notes.md
@@ -1,6 +1,10 @@
-# Release 2.10.4.0
+# Next Release
 ## What's New
-* updated to ziti-edge-tunnel v1.14.6
+* [Issue 818](https://github.com/openziti/desktop-edge-win/issues/818) - Added update progress UI
+  * Update service sends progress and failure status to the UI during updates
+  * Upgrade sentinel shows a dismissable progress dialog on user-triggered updates
+  * Update failures are shown to the user instead of silently hanging
+  * Automatic updates now relaunch the UI after the install completes if the UI was running prior to the update
 
 ## Bugs fixed
 n/a


### PR DESCRIPTION
- UpdateService now sends progress (Downloading, Verifying, Installing) and failure events to the UI during updates. The UI shows these as a loading overlay until the service sends the existing "Upgrading" message and shuts the UI down.
- The upgrade sentinel can now show a WinForms progress dialog while it waits for the service to restart. This only appears on user-triggered updates and can be permanently dismissed with a "Don't show this again" checkbox that writes a preference file to `%APPDATA%\NetFoundry\hide-upgrade-progress`. The sentinel's named pipe calls now use connect timeouts instead of blocking indefinitely so the dialog can update its status while waiting.
- If an update fails, the UI kills the sentinel, hides the loading overlay, and shows the error to the user.
- The sentinel is now also started on automatic updates. If the UI is running and the monitor runs the installation - the UI comes back up after the install
- Closes #818