### PR TITLE
allow targetting a particular zet instance

### DIFF
--- a/DesktopEdge/MainWindow.xaml
+++ b/DesktopEdge/MainWindow.xaml
@@ -360,6 +360,22 @@
                 </Grid.ColumnDefinitions>
                 <Label Name="AddIdButton" Padding="0,0,0,0" Grid.Column="0" Margin="0,0,0,0" Content=""  Foreground="#0069FF" FontSize="12 " HorizontalAlignment="Center" VerticalAlignment="Center" ></Label>
             </Grid>
+            <Border x:Name="AlternateTunnelFooter"
+                    Visibility="Collapsed"
+                    Margin="14,0,14,10"
+                    Padding="10,6,10,6"
+                    CornerRadius="4"
+                    BorderThickness="1"
+                    BorderBrush="#4AC84A"
+                    Background="#1F2E23">
+                <TextBlock x:Name="AlternateTunnelFooterText"
+                           Foreground="#CDEFD1"
+                           FontFamily="Segoe UI"
+                           FontSize="11"
+                           TextWrapping="Wrap"
+                           TextAlignment="Center"
+                           Text=""/>
+            </Border>
         </StackPanel>
         <Canvas x:Name="AlertCanvas" ClipToBounds="False" Visibility="Collapsed">
             <Image Source="/Assets/Images/UpdateWarn.png" Canvas.Left="50" Canvas.Top="32" Width="14" Height="14"></Image>

--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -566,6 +566,161 @@ namespace ZitiDesktopEdge {
                 if (IdentityMenu.Visibility == Visibility.Visible) IdentityMenu.Visibility = Visibility.Collapsed;
                 else if (MainMenu.Visibility == Visibility.Visible) MainMenu.Visibility = Visibility.Collapsed;
             }
+
+            // Ctrl+Shift+T : open the dev-only tunneler instance picker
+            if (e.Key == Key.T
+                    && (Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control
+                    && (Keyboard.Modifiers & ModifierKeys.Shift) == ModifierKeys.Shift) {
+                OpenTunnelInstancePicker();
+                e.Handled = true;
+            }
+        }
+
+        private void OpenTunnelInstancePicker() {
+            // If there's only one ziti-edge-tunnel instance running, there's
+            // nothing useful to switch to — suppress the picker entirely.
+            _ = OpenTunnelInstancePickerAsync();
+        }
+
+        private async Task OpenTunnelInstancePickerAsync() {
+            try {
+                var instances = await TunnelInstanceDiscovery.EnumerateAsync();
+                if (instances.Count <= 1) {
+                    logger.Debug("Ctrl+Shift+T ignored — only {0} tunneler instance running", instances.Count);
+                    return;
+                }
+            } catch (Exception ex) {
+                logger.Debug(ex, "enumeration failed when opening picker; showing it anyway");
+            }
+
+            bool picked = false;
+            string chosen = null;
+            this.Dispatcher.Invoke(() => {
+                string tmp;
+                picked = PromptForInstance(out tmp);
+                chosen = tmp;
+            });
+            if (picked) {
+                await SwitchToInstanceAsync(chosen);
+            }
+        }
+
+        /// <summary>
+        /// Shows the picker modally. Returns true if the user chose an instance
+        /// (populating <paramref name="discriminator"/> with null for default
+        /// or the picked name); false if the user dismissed the dialog.
+        /// </summary>
+        private bool PromptForInstance(out string discriminator) {
+            discriminator = null;
+            try {
+                var picker = new TunnelInstancePickerWindow(serviceClient?.Discriminator);
+                if (this.IsLoaded) picker.Owner = this;
+                bool? dialog = picker.ShowDialog();
+                if (dialog == true && picker.InstanceSelected) {
+                    discriminator = picker.SelectedDiscriminator;
+                    return true;
+                }
+            } catch (Exception ex) {
+                logger.Error(ex, "failed to open tunnel instance picker");
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Startup: pick whichever ziti-edge-tunnel instance to connect to.
+        /// Rules:
+        ///   0 running          — fall back to the default-pipe reconnect loop.
+        ///   1 running          — connect to it, default or not.
+        ///   2+ with default    — connect to default (preserves prior behaviour).
+        ///   2+ without default — pop the picker; user cancel → reconnect loop.
+        /// </summary>
+        private async Task ChooseAndConnectOnStartupAsync() {
+            IReadOnlyList<TunnelInstanceDiscovery.TunnelInstance> instances = null;
+            try {
+                instances = await TunnelInstanceDiscovery.EnumerateAsync();
+            } catch (Exception ex) {
+                logger.Debug(ex, "instance enumeration failed on startup");
+            }
+
+            if (instances == null || instances.Count == 0) {
+                logger.Info("no running ziti-edge-tunnel instances found on startup — entering reconnect loop on default");
+                ShowServiceNotStarted();
+                serviceClient.Reconnect();
+                return;
+            }
+
+            if (instances.Count == 1) {
+                var only = instances[0];
+                logger.Info("exactly one tunnel instance running on startup ('{0}') — auto-connecting", only.DisplayLabel);
+                await SwitchToInstanceAsync(only.Discriminator);
+                return;
+            }
+
+            var def = instances.FirstOrDefault(i => string.IsNullOrEmpty(i.Discriminator));
+            if (def != null) {
+                logger.Info("{0} instances running on startup, default is one of them — connecting to default", instances.Count);
+                await SwitchToInstanceAsync(null);
+                return;
+            }
+
+            logger.Info("{0} tunnel instances running on startup, none is the default — opening picker", instances.Count);
+            string chosen;
+            if (PromptForInstance(out chosen)) {
+                await SwitchToInstanceAsync(chosen);
+            } else {
+                ShowServiceNotStarted();
+                serviceClient.Reconnect();
+            }
+        }
+
+
+        private async Task SwitchToInstanceAsync(string discriminator) {
+            logger.Info("switching tunneler instance to '{0}'", discriminator ?? "default");
+            this.Dispatcher.Invoke(() => {
+                ResetTunnelerScopedState();
+                ShowLoad("Switching tunneler", "Connecting to '" + (discriminator ?? "default") + "'…");
+            });
+            try {
+                await serviceClient.SwitchInstanceAsync(discriminator);
+                this.Dispatcher.Invoke(() => HideLoad());
+            } catch (Exception ex) {
+                logger.Error(ex, "failed to switch tunneler instance to '{0}'", discriminator ?? "default");
+                this.Dispatcher.Invoke(() => {
+                    HideLoad();
+                    ShowError("Switch failed", "Could not connect to '" + (discriminator ?? "default") + "': " + ex.Message);
+                    ShowServiceNotStarted();
+                });
+            }
+        }
+
+        /// <summary>
+        /// True when the UI is currently viewing the default ziti-edge-tunnel
+        /// instance. The big start/stop/force-terminate button always targets
+        /// the default Windows service regardless; this is purely for
+        /// cosmetic signals (e.g. the alternate-tunnel footer).
+        /// </summary>
+        private bool IsViewingDefaultInstance {
+            get { return string.IsNullOrEmpty(serviceClient?.Discriminator); }
+        }
+
+        /// <summary>
+        /// Show/hide the "you are viewing an alternate tunneler" footer based
+        /// on the current <see cref="DataClient.Discriminator"/>. Safe to call
+        /// from any thread — bounces to the Dispatcher.
+        /// </summary>
+        private void UpdateAlternateTunnelFooter() {
+            this.Dispatcher.Invoke(() => {
+                if (AlternateTunnelFooter == null) return;
+                string disc = serviceClient?.Discriminator;
+                if (string.IsNullOrEmpty(disc)) {
+                    AlternateTunnelFooter.Visibility = Visibility.Collapsed;
+                    AlternateTunnelFooterText.Text = "";
+                } else {
+                    AlternateTunnelFooter.Visibility = Visibility.Visible;
+                    AlternateTunnelFooterText.Text =
+                        "viewing alternate tunneler: ziti-edge-tunnel.sock." + disc;
+                }
+            });
         }
 
         private void MFASetup_OnLoad(bool isComplete, string title, string message) {
@@ -763,14 +918,7 @@ namespace ZitiDesktopEdge {
             MainMenu.OnShowBlurb += MainMenu_OnShowBlurb;
             IdentityMenu.OnError += IdentityMenu_OnError;
 
-            try {
-                await serviceClient.ConnectAsync();
-                await serviceClient.WaitForConnectionAsync();
-            } catch /*ignored for now (Exception ex) */
-              {
-                ShowServiceNotStarted();
-                serviceClient.Reconnect();
-            }
+            await ChooseAndConnectOnStartupAsync();
 
             try {
                 await monitorClient.ConnectAsync();
@@ -980,8 +1128,22 @@ namespace ZitiDesktopEdge {
                             logger.Info("Service is stopping...");
 
                             this.Dispatcher.Invoke(async () => {
-                                SetCantDisplay("The Service is Stopping", "Please wait while the service stops", Visibility.Visible);
-                                await WaitForServiceToStop(DateTime.Now + TimeSpan.FromSeconds(30));
+                                ShowLoad("Service is Stopping", "Please wait while the service stops");
+                                try {
+                                    await WaitForServiceToStop(DateTime.Now + TimeSpan.FromSeconds(30));
+                                } finally {
+                                    // Wipe identity UI before removing the modal so the
+                                    // user doesn't briefly see stale identities after the
+                                    // modal disappears (ClientDisconnected would clear
+                                    // them a moment later, but that's visibly laggy).
+                                    // If WaitForServiceToStop hit its timeout it has
+                                    // already replaced the modal with the "Service
+                                    // Appears Stuck" error (which owns the Force Quit
+                                    // button); HideLoad in that case is a harmless no-op
+                                    // on the already-hidden modal.
+                                    ResetTunnelerScopedState();
+                                    HideLoad();
+                                }
                             });
                             break;
                         case ServiceControllerStatus.StartPending:
@@ -1150,6 +1312,8 @@ namespace ZitiDesktopEdge {
         async private void ForceQuitButtonClick(object sender, RoutedEventArgs e) {
             if (!UIUtils.IsLeftClick(e)) return;
             if (!UIUtils.MouseUpForMouseDown(e)) return;
+            // Targets the default Windows-service-managed tunneler regardless
+            // of which instance is currently being viewed.
             MonitorServiceStatusEvent status = await monitorClient.ForceTerminateAsync();
             if (status.IsStopped()) {
                 //good
@@ -1164,6 +1328,7 @@ namespace ZitiDesktopEdge {
         async private void StartZitiService(object sender, RoutedEventArgs e) {
             if (!UIUtils.IsLeftClick(e)) return;
             if (!UIUtils.MouseUpForMouseDown(e)) return;
+            // Always targets the default Windows service.
             try {
                 ShowLoad("Starting", "Starting the data service");
                 logger.Info("StartZitiService");
@@ -1234,30 +1399,86 @@ namespace ZitiDesktopEdge {
                 UpdateServiceView();
                 SetNotifyIcon("white");
                 LoadIdentities(true);
+                UpdateAlternateTunnelFooter();
             });
         }
 
         private void ServiceClient_OnClientDisconnected(object sender, object e) {
             this.Dispatcher.Invoke(() => {
-                AddIdAreaButton.IsEnabled = false;
-                IdentityMenu.Visibility = Visibility.Collapsed;
-                MFASetup.Visibility = Visibility.Collapsed;
-                HideModal();
-                MainMenu.Disconnected();
-                for (int i = 0; i < IdList.Children.Count; i++) {
-                    IdentityItem item = (IdentityItem)IdList.Children[i];
-                    item.StopTimers();
-                }
-                IdList.Children.Clear();
-                identities.Clear();
+                ResetTunnelerScopedState();
                 if (e != null) {
                     logger.Debug(e.ToString());
                 }
-                //SetCantDisplay("Start the Ziti Tunnel Service to continue");
                 SetNotifyIcon("red");
-                _notificationThrottle.Clear();
                 ShowServiceNotStarted();
+                // The underlying DataClient has already kicked off its own
+                // reconnect loop against whatever pipe we were viewing. If the
+                // user wants to view a different instance they can hit
+                // Ctrl+Shift+T.
             });
+        }
+
+        /// <summary>
+        /// Wipes all UI and in-memory state scoped to the currently-connected
+        /// ziti-edge-tunnel instance. Safe to call when nothing is connected.
+        /// Called by the disconnect handler and (later) by the instance switcher
+        /// before reconnecting to a different tunneler.
+        ///
+        /// Must be invoked on the UI thread.
+        /// </summary>
+        private void ResetTunnelerScopedState() {
+            AddIdAreaButton.IsEnabled = false;
+            IdentityMenu.Visibility = Visibility.Collapsed;
+            MFASetup.Visibility = Visibility.Collapsed;
+            HideModal();
+            MainMenu.Disconnected();
+
+            for (int i = 0; i < IdList.Children.Count; i++) {
+                IdentityItem item = (IdentityItem)IdList.Children[i];
+                item.StopTimers();
+            }
+            IdList.Children.Clear();
+            identities.Clear();
+
+            StopTunnelUptimeTimer();
+            _startDate = default(DateTime);
+            ConnectedTime.Content = "00:00:00";
+
+            DownloadSpeed.Content = "0.0";
+            UploadSpeed.Content = "0.0";
+
+            _notificationThrottle?.Clear();
+            NextNotificationTime = DateTime.Now;
+
+            var props = Application.Current.Properties;
+            props.Remove("CurrentTunnelStatus");
+            props.Remove("ip");
+            props.Remove("subnet");
+            props.Remove("mtu");
+            props.Remove("dns");
+            props.Remove("dnsenabled");
+            props.Remove("ApiPageSize");
+            props.Remove("L2Enabled");
+            props.Remove("PcapInterface");
+
+            // Hide the alternate-tunnel footer while we're not connected; it
+            // will come back when ClientConnected fires (discriminator
+            // persists across a reconnect on the same pipe).
+            if (AlternateTunnelFooter != null) {
+                AlternateTunnelFooter.Visibility = Visibility.Collapsed;
+            }
+        }
+
+        private void StopTunnelUptimeTimer() {
+            if (_tunnelUptimeTimer == null) return;
+            try {
+                _tunnelUptimeTimer.Stop();
+                _tunnelUptimeTimer.Tick -= OnTimedEvent;
+                _tunnelUptimeTimer.Dispose();
+            } catch (Exception ex) {
+                logger.Debug(ex, "error while stopping tunnel uptime timer");
+            }
+            _tunnelUptimeTimer = null;
         }
 
         /// <summary>
@@ -1990,6 +2211,7 @@ namespace ZitiDesktopEdge {
         }
 
         private void InitializeTimer(int millisAgoStarted) {
+            StopTunnelUptimeTimer();
             _startDate = DateTime.Now.Subtract(new TimeSpan(0, 0, 0, 0, millisAgoStarted));
             _tunnelUptimeTimer = new System.Windows.Forms.Timer();
             _tunnelUptimeTimer.Interval = 100;
@@ -2001,6 +2223,7 @@ namespace ZitiDesktopEdge {
         async private void Disconnect(object sender, RoutedEventArgs e) {
             if (!UIUtils.IsLeftClick(e)) return;
             if (!UIUtils.MouseUpForMouseDown(e)) return;
+            // Always targets the default Windows service.
             try {
                 ShowLoad("Disabling Service", "Please wait for the service to stop.");
                 var r = await monitorClient.StopServiceAsync();

--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -627,47 +627,17 @@ namespace ZitiDesktopEdge {
         }
 
         /// <summary>
-        /// Startup: pick whichever ziti-edge-tunnel instance to connect to.
-        /// Rules:
-        ///   0 running          — fall back to the default-pipe reconnect loop.
-        ///   1 running          — connect to it, default or not.
-        ///   2+ with default    — connect to default (preserves prior behaviour).
-        ///   2+ without default — pop the picker; user cancel → reconnect loop.
+        /// Startup: connect to the default ziti-edge-tunnel instance. If it
+        /// isn't running, show the not-started banner and let the reconnect
+        /// loop poll for it. Non-default instances are reached exclusively via
+        /// the Ctrl+Shift+T picker — startup never auto-routes to them.
         /// </summary>
         private async Task ChooseAndConnectOnStartupAsync() {
-            IReadOnlyList<TunnelInstanceDiscovery.TunnelInstance> instances = null;
             try {
-                instances = await TunnelInstanceDiscovery.EnumerateAsync();
-            } catch (Exception ex) {
-                logger.Debug(ex, "instance enumeration failed on startup");
-            }
-
-            if (instances == null || instances.Count == 0) {
-                logger.Info("no running ziti-edge-tunnel instances found on startup — entering reconnect loop on default");
-                ShowServiceNotStarted();
-                serviceClient.Reconnect();
-                return;
-            }
-
-            if (instances.Count == 1) {
-                var only = instances[0];
-                logger.Info("exactly one tunnel instance running on startup ('{0}') — auto-connecting", only.DisplayLabel);
-                await SwitchToInstanceAsync(only.Discriminator);
-                return;
-            }
-
-            var def = instances.FirstOrDefault(i => string.IsNullOrEmpty(i.Discriminator));
-            if (def != null) {
-                logger.Info("{0} instances running on startup, default is one of them — connecting to default", instances.Count);
-                await SwitchToInstanceAsync(null);
-                return;
-            }
-
-            logger.Info("{0} tunnel instances running on startup, none is the default — opening picker", instances.Count);
-            string chosen;
-            if (PromptForInstance(out chosen)) {
-                await SwitchToInstanceAsync(chosen);
-            } else {
+                await serviceClient.ConnectAsync();
+                await serviceClient.WaitForConnectionAsync();
+            } catch /*ignored for now (Exception ex) */
+              {
                 ShowServiceNotStarted();
                 serviceClient.Reconnect();
             }

--- a/DesktopEdge/TunnelInstancePickerWindow.cs
+++ b/DesktopEdge/TunnelInstancePickerWindow.cs
@@ -1,0 +1,219 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
+
+using ZitiDesktopEdge.ServiceClient;
+
+namespace ZitiDesktopEdge {
+    /// <summary>
+    /// Dev-grade picker: enumerates all running ziti-edge-tunnel instances and
+    /// lets the user click one to switch ZDEW's view to it. Pure-code WPF
+    /// window — intentionally minimal. Replace with a polished MainMenu entry
+    /// once the plumbing is proven.
+    ///
+    /// Opened with Ctrl+Shift+T from MainWindow.
+    /// </summary>
+    public class TunnelInstancePickerWindow : Window {
+        public string SelectedDiscriminator { get; private set; }
+        public bool InstanceSelected { get; private set; }
+
+        private readonly StackPanel stack;
+        private readonly TextBlock statusLabel;
+        private readonly string activeDiscriminator;
+
+        public TunnelInstancePickerWindow(string activeDiscriminator) {
+            this.activeDiscriminator = activeDiscriminator;
+            Title = "Switch tunneler instance (dev)";
+            Width = 420;
+            Height = 360;
+            WindowStartupLocation = WindowStartupLocation.CenterOwner;
+            ResizeMode = ResizeMode.NoResize;
+            Background = new SolidColorBrush(Color.FromRgb(0x1e, 0x1e, 0x28));
+
+            var root = new DockPanel { Margin = new Thickness(12) };
+
+            statusLabel = new TextBlock {
+                Text = "enumerating pipes…",
+                Foreground = Brushes.Gainsboro,
+                Margin = new Thickness(2, 2, 2, 8),
+                FontFamily = new FontFamily("Segoe UI")
+            };
+            DockPanel.SetDock(statusLabel, Dock.Top);
+            root.Children.Add(statusLabel);
+
+            var refreshBtn = new Button {
+                Content = "Refresh",
+                Margin = new Thickness(2, 0, 2, 8),
+                Padding = new Thickness(8, 4, 8, 4),
+                HorizontalAlignment = HorizontalAlignment.Right
+            };
+            refreshBtn.Click += async (_, __) => await PopulateAsync();
+            DockPanel.SetDock(refreshBtn, Dock.Top);
+            root.Children.Add(refreshBtn);
+
+            var scroll = new ScrollViewer {
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                Background = Brushes.Transparent
+            };
+            stack = new StackPanel();
+            scroll.Content = stack;
+            root.Children.Add(scroll);
+
+            Content = root;
+            Loaded += async (_, __) => await PopulateAsync();
+        }
+
+        private async Task PopulateAsync() {
+            stack.Children.Clear();
+            statusLabel.Text = "enumerating pipes…";
+
+            IReadOnlyList<TunnelInstanceDiscovery.TunnelInstance> discovered;
+            try {
+                discovered = await TunnelInstanceDiscovery.EnumerateAsync();
+            } catch (Exception ex) {
+                statusLabel.Text = "enumeration failed: " + ex.Message;
+                return;
+            }
+
+            // Assemble the display list: default is always first, synthetic if
+            // it's not actually running. Everything else follows in the order
+            // discovery returned them.
+            var ordered = new List<TunnelInstanceDiscovery.TunnelInstance>();
+            var def = discovered.FirstOrDefault(i => string.IsNullOrEmpty(i.Discriminator));
+            ordered.Add(def ?? TunnelInstanceDiscovery.OfflineDefault());
+            foreach (var inst in discovered) {
+                if (!string.IsNullOrEmpty(inst.Discriminator)) ordered.Add(inst);
+            }
+
+            int liveCount = ordered.Count(i => i.IsOnline);
+            statusLabel.Text = liveCount == 0
+                ? "no tunnelers running. start one or click default to retry."
+                : (liveCount == 1 ? "1 instance running." : liveCount + " instances running.")
+                    + " click to switch.";
+
+            foreach (var inst in ordered) {
+                stack.Children.Add(BuildInstanceRow(inst));
+            }
+        }
+
+        private static readonly Color RowBg = Color.FromRgb(0x2a, 0x2a, 0x38);
+        private static readonly Color RowBgHover = Color.FromRgb(0x36, 0x36, 0x48);
+        private static readonly Color RowBorder = Color.FromRgb(0x3a, 0x3a, 0x48);
+        private static readonly Color ActiveBg = Color.FromRgb(0x23, 0x35, 0x28);
+        private static readonly Color ActiveBorder = Color.FromRgb(0x4a, 0xc8, 0x4a);
+
+        private FrameworkElement BuildInstanceRow(TunnelInstanceDiscovery.TunnelInstance inst) {
+            bool isActive = string.Equals(inst.Discriminator ?? "", activeDiscriminator ?? "", StringComparison.Ordinal)
+                            && inst.IsOnline;
+
+            string suffix = isActive ? "   (active)" : (!inst.IsOnline ? "   (not running)" : "");
+            var panel = new StackPanel { Orientation = Orientation.Vertical };
+            panel.Children.Add(new TextBlock {
+                Text = inst.DisplayLabel + suffix,
+                FontWeight = FontWeights.Bold,
+                Foreground = inst.IsOnline ? Brushes.White : new SolidColorBrush(Color.FromRgb(0xa0, 0xa0, 0xa8)),
+                FontFamily = new FontFamily("Segoe UI")
+            });
+
+            string subtitle;
+            if (!inst.IsOnline) {
+                subtitle = "pipe: " + inst.PipeName + "    — click to attempt connect";
+            } else {
+                subtitle = "pipe: " + inst.PipeName;
+                if (!string.IsNullOrEmpty(inst.TunName)) subtitle += "    tun: " + inst.TunName;
+                if (!string.IsNullOrEmpty(inst.Ip)) subtitle += "    ip: " + inst.Ip;
+                if (!string.IsNullOrEmpty(inst.Dns)) subtitle += "    dns: " + inst.Dns;
+            }
+            panel.Children.Add(new TextBlock {
+                Text = subtitle,
+                Foreground = inst.IsOnline ? Brushes.LightGray : new SolidColorBrush(Color.FromRgb(0x80, 0x80, 0x88)),
+                FontSize = 11,
+                FontFamily = new FontFamily("Consolas"),
+                TextWrapping = TextWrapping.Wrap
+            });
+
+            if (isActive) {
+                // Non-interactive — a Border avoids any WPF default hover styling.
+                return new Border {
+                    Child = panel,
+                    Margin = new Thickness(0, 0, 0, 6),
+                    Padding = new Thickness(12, 8, 12, 8),
+                    Background = new SolidColorBrush(ActiveBg),
+                    BorderBrush = new SolidColorBrush(ActiveBorder),
+                    BorderThickness = new Thickness(2),
+                    CornerRadius = new CornerRadius(2),
+                };
+            }
+
+            var btn = new Button {
+                Content = panel,
+                Margin = new Thickness(0, 0, 0, 6),
+                Padding = new Thickness(12, 8, 12, 8),
+                HorizontalContentAlignment = HorizontalAlignment.Left,
+                Foreground = Brushes.White,
+                Cursor = System.Windows.Input.Cursors.Hand,
+                Template = BuildRowTemplate()
+            };
+            btn.Click += (_, __) => {
+                SelectedDiscriminator = inst.Discriminator;
+                InstanceSelected = true;
+                DialogResult = true;
+                Close();
+            };
+            return btn;
+        }
+
+        /// <summary>
+        /// Minimal ControlTemplate for row buttons. Replaces the WPF default
+        /// (which flips to a light-blue on hover, unusable against the dark
+        /// theme) with a two-state dark-on-darker hover.
+        /// </summary>
+        private static ControlTemplate BuildRowTemplate() {
+            var tpl = new ControlTemplate(typeof(Button));
+            var border = new FrameworkElementFactory(typeof(Border));
+            border.Name = "RowBorder";
+            border.SetValue(Border.BackgroundProperty, new SolidColorBrush(RowBg));
+            border.SetValue(Border.BorderBrushProperty, new SolidColorBrush(RowBorder));
+            border.SetValue(Border.BorderThicknessProperty, new Thickness(1));
+            border.SetValue(Border.CornerRadiusProperty, new CornerRadius(2));
+            border.SetValue(Border.PaddingProperty, new TemplateBindingExtension(Control.PaddingProperty));
+
+            var presenter = new FrameworkElementFactory(typeof(ContentPresenter));
+            presenter.SetValue(ContentPresenter.HorizontalAlignmentProperty, HorizontalAlignment.Left);
+            presenter.SetValue(ContentPresenter.VerticalAlignmentProperty, VerticalAlignment.Center);
+            border.AppendChild(presenter);
+            tpl.VisualTree = border;
+
+            var hoverTrigger = new Trigger { Property = UIElement.IsMouseOverProperty, Value = true };
+            hoverTrigger.Setters.Add(new Setter(Border.BackgroundProperty, new SolidColorBrush(RowBgHover), "RowBorder"));
+            tpl.Triggers.Add(hoverTrigger);
+
+            var pressedTrigger = new Trigger { Property = ButtonBase.IsPressedProperty, Value = true };
+            pressedTrigger.Setters.Add(new Setter(Border.BackgroundProperty, new SolidColorBrush(ActiveBg), "RowBorder"));
+            tpl.Triggers.Add(pressedTrigger);
+
+            return tpl;
+        }
+    }
+}

--- a/DesktopEdge/Views/Controls/AddIdentityUrl.xaml.cs
+++ b/DesktopEdge/Views/Controls/AddIdentityUrl.xaml.cs
@@ -79,6 +79,7 @@ namespace ZitiDesktopEdge {
                 AddIdentityViewModel.LoadSigners(body);
                 return true;
             } catch (Exception ex) {
+                logger.Error(ex, "connecting to the url provided failed");
                 await ShowConnectionErrorAsync(ex);
                 return false;
             } finally {

--- a/DesktopEdge/ZitiDesktopEdge.csproj
+++ b/DesktopEdge/ZitiDesktopEdge.csproj
@@ -284,6 +284,7 @@
     <Compile Include="Views\ItemRenderers\IdentityItem.xaml.cs">
       <DependentUpon>IdentityItem.xaml</DependentUpon>
     </Compile>
+    <Compile Include="TunnelInstancePickerWindow.cs" />
     <Compile Include="MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/ZitiDesktopEdge.Client/ServiceClient/AbstractClient.cs
+++ b/ZitiDesktopEdge.Client/ServiceClient/AbstractClient.cs
@@ -42,6 +42,31 @@ namespace ZitiDesktopEdge.ServiceClient {
 
         protected NamedPipeClientStream pipeClient = null;
         protected NamedPipeClientStream eventClient = null;
+
+        /// <summary>
+        /// Set by subclasses during an in-flight instance switch. When true, the
+        /// disconnect path must not kick off the auto-reconnect loop or fire the
+        /// OnClientDisconnected event — the caller is orchestrating the swap and
+        /// will reconnect to a new pipe explicitly.
+        /// </summary>
+        protected volatile bool SwitchInProgress;
+
+        /// <summary>
+        /// Monotonic counter bumped every time the live pipe pair is replaced
+        /// (reconnect, or explicit instance switch). Each event-reader task
+        /// captures the value when it starts and only reports its own
+        /// disconnection if the counter still matches on exit — stale readers
+        /// from a prior connection stay silent.
+        /// </summary>
+        private int _connectionGeneration;
+
+        protected int BumpConnectionGeneration() {
+            return System.Threading.Interlocked.Increment(ref _connectionGeneration);
+        }
+
+        protected int CurrentConnectionGeneration {
+            get { return System.Threading.Volatile.Read(ref _connectionGeneration); }
+        }
         protected StreamWriter ipcWriter = null;
         protected StreamReader ipcReader = null;
         protected abstract Task ConnectPipesAsync();
@@ -63,6 +88,7 @@ namespace ZitiDesktopEdge.ServiceClient {
             ExpectedShutdown = false;
             Logger.Debug("Client connected successfully. Setting UnexpectedShutdown set to false.");
 
+            int readerGen = BumpConnectionGeneration();
             ipcWriter = new StreamWriter(pipeClient);
             ipcReader = new StreamReader(pipeClient);
             Task.Run(async () => { //hack for now until it's async...
@@ -74,7 +100,7 @@ namespace ZitiDesktopEdge.ServiceClient {
                             }
                             string respAsString = null;
                             try {
-                                respAsString = await readMessageAsync("event", eventReader);
+                                respAsString = await readMessageAsync("event", eventReader, readerGen);
                                 try {
                                     ProcessLine(respAsString);
                                 } catch (Exception ex) {
@@ -89,8 +115,16 @@ namespace ZitiDesktopEdge.ServiceClient {
                     Logger.Debug("unepxected error: " + ex.ToString());
                 }
 
-                // since this thread is always sitting waiting to read
-                // it should be the only one triggering this event
+                // Only report the disconnect if we're still the active reader.
+                // A SwitchInstanceAsync (or any other force-replace of the pipe
+                // pair) bumps the generation; the stale reader's async callback
+                // can land long after the new connection is live, so comparing
+                // generations keeps it from kicking off a spurious reconnect
+                // cycle.
+                if (readerGen != CurrentConnectionGeneration) {
+                    Logger.Debug("stale event-reader exit ignored (readerGen={0}, current={1})", readerGen, CurrentConnectionGeneration);
+                    return;
+                }
                 ClientDisconnected(null);
             });
             OnClientConnected?.Invoke(this, e);
@@ -170,6 +204,18 @@ namespace ZitiDesktopEdge.ServiceClient {
             await ConnectPipesAsync();
         }
 
+        /// <summary>
+        /// Set by <see cref="AbortReconnect"/> to ask an in-flight reconnect
+        /// loop to bail out. Checked after each Task.Delay so an external
+        /// caller taking over the pipe pair (e.g. an explicit instance
+        /// switch) doesn't race against the retry loop.
+        /// </summary>
+        private volatile bool _abortReconnect;
+
+        public void AbortReconnect() {
+            _abortReconnect = true;
+        }
+
         public void Reconnect() {
             if (Reconnecting) {
                 Logger.Debug("Already in reconnect mode.");
@@ -177,6 +223,7 @@ namespace ZitiDesktopEdge.ServiceClient {
             } else {
                 Reconnecting = true;
             }
+            _abortReconnect = false;
 
             Task.Run(async () => {
                 Logger.Info("service is down. attempting to connect to service...");
@@ -184,9 +231,16 @@ namespace ZitiDesktopEdge.ServiceClient {
                 DateTime reconnectStart = DateTime.Now;
                 DateTime logAgainAfter = reconnectStart + TimeSpan.FromSeconds(1);
 
-                while (true) {
+                while (!_abortReconnect) {
                     try {
                         await Task.Delay(2500);
+                        if (_abortReconnect) break;
+                        if (Connected) {
+                            // Someone else (e.g. SwitchInstanceAsync) connected
+                            // while we were sleeping. Exit quietly.
+                            Reconnecting = false;
+                            return;
+                        }
                         await ConnectPipesAsync();
 
                         if (Connected) {
@@ -219,6 +273,7 @@ namespace ZitiDesktopEdge.ServiceClient {
                         }
                     }
                 }
+                Reconnecting = false;
             });
         }
 
@@ -271,6 +326,20 @@ namespace ZitiDesktopEdge.ServiceClient {
         }
 
         async public Task<string> readMessageAsync(string channel, StreamReader reader) {
+            return await readMessageAsync(channel, reader, null);
+        }
+
+        /// <summary>
+        /// Same as <see cref="readMessageAsync(string, StreamReader)"/> but
+        /// with optional generation awareness. Callers running as part of a
+        /// long-lived reader task (e.g. the event channel) should pass the
+        /// generation captured when the reader started. If the pipe was
+        /// replaced beneath us (instance switch, reconnect) we no longer own
+        /// the stream and must not fire ClientDisconnected — that would kick
+        /// off a redundant reconnect cycle on top of the one already in
+        /// flight.
+        /// </summary>
+        async public Task<string> readMessageAsync(string channel, StreamReader reader, int? readerGeneration) {
             try {
                 int emptyCount = 1; //just a stop gap in case something crazy happens in the communication
 
@@ -291,15 +360,28 @@ namespace ZitiDesktopEdge.ServiceClient {
                 return respAsString;
             } catch (IOException ioe) {
                 //almost certainly a problem with the pipe
-                Logger.Error(ioe, "io error in read: " + ioe.Message);
-                ClientDisconnected(null);
+                if (IsCurrentReader(readerGeneration)) {
+                    Logger.Error(ioe, "io error in read: " + ioe.Message);
+                    ClientDisconnected(null);
+                } else {
+                    Logger.Debug("io error from stale reader ignored (gen={0}, current={1}): {2}", readerGeneration, CurrentConnectionGeneration, ioe.Message);
+                }
                 throw ioe;
             } catch (Exception ee) {
                 //almost certainly a problem with the pipe
-                Logger.Error(ee, "unexpected error in read: " + ee.Message);
-                ClientDisconnected(null);
+                if (IsCurrentReader(readerGeneration)) {
+                    Logger.Error(ee, "unexpected error in read: " + ee.Message);
+                    ClientDisconnected(null);
+                } else {
+                    Logger.Debug("read error from stale reader ignored (gen={0}, current={1}): {2}", readerGeneration, CurrentConnectionGeneration, ee.Message);
+                }
                 throw ee;
             }
+        }
+
+        private bool IsCurrentReader(int? readerGeneration) {
+            if (!readerGeneration.HasValue) return true; // caller opted out of the check
+            return readerGeneration.Value == CurrentConnectionGeneration;
         }
 
         async public Task WaitForConnectionAsync() {

--- a/ZitiDesktopEdge.Client/ServiceClient/DataClient.cs
+++ b/ZitiDesktopEdge.Client/ServiceClient/DataClient.cs
@@ -101,16 +101,88 @@ namespace ZitiDesktopEdge.ServiceClient {
         }
 
         protected override void ClientDisconnected(object e) {
+            if (SwitchInProgress) {
+                // The caller is orchestrating an instance switch — stay quiet; they
+                // will call ConnectPipesAsync again against the new pipe names.
+                Connected = false;
+                return;
+            }
             Reconnect();
             Connected = false;
             base.ClientDisconnected(e);
         }
 
         // ziti edge tunnel
-        const string ipcPipe = @"ziti-edge-tunnel.sock";
-        const string eventPipe = @"ziti-edge-tunnel-event.sock";
+        private const string DefaultIpcPipe = @"ziti-edge-tunnel.sock";
+        private const string DefaultEventPipe = @"ziti-edge-tunnel-event.sock";
 
-        public DataClient(string id) : base(id) {
+        private string ipcPipe;
+        private string eventPipe;
+
+        /// <summary>
+        /// The discriminator supplied to ziti-edge-tunnel via its -P|--pipe flag.
+        /// null (or empty) means the default instance (no discriminator).
+        /// </summary>
+        public string Discriminator { get; private set; }
+
+        public DataClient(string id) : this(id, null) {
+        }
+
+        public DataClient(string id, string discriminator) : base(id) {
+            ApplyDiscriminator(discriminator);
+        }
+
+        private void ApplyDiscriminator(string discriminator) {
+            Discriminator = string.IsNullOrEmpty(discriminator) ? null : discriminator;
+            if (Discriminator == null) {
+                ipcPipe = DefaultIpcPipe;
+                eventPipe = DefaultEventPipe;
+            } else {
+                ipcPipe = DefaultIpcPipe + "." + Discriminator;
+                eventPipe = DefaultEventPipe + "." + Discriminator;
+            }
+        }
+
+        /// <summary>
+        /// Switch this client from the currently-connected ziti-edge-tunnel
+        /// instance to the one identified by <paramref name="discriminator"/>
+        /// (null/empty means the default instance). The caller is responsible
+        /// for resetting any UI state tied to the previous instance BEFORE
+        /// calling this — the normal OnClientDisconnected event is suppressed
+        /// while the swap is in progress so the UI does not flash "service not
+        /// started".
+        ///
+        /// On return the new pipes are connected and event delivery has
+        /// resumed; a fresh TunnelStatusEvent will repopulate identities.
+        /// </summary>
+        public async Task SwitchInstanceAsync(string discriminator) {
+            string newDisc = string.IsNullOrEmpty(discriminator) ? null : discriminator;
+            if (newDisc == Discriminator && Connected) {
+                return;
+            }
+
+            // Ask any background reconnect loop to bail out — we're about to
+            // take the pipes over. Without this, the loop can race with our
+            // own ConnectPipesAsync and produce a parallel event reader.
+            AbortReconnect();
+
+            SwitchInProgress = true;
+            try {
+                // Bump generation BEFORE disposing so the stale event-reader
+                // task — which may take tens of milliseconds to notice the
+                // dispose — sees a mismatch when it exits and stays silent.
+                BumpConnectionGeneration();
+                try { pipeClient?.Dispose(); } catch (Exception ex) { Logger.Debug(ex, "error disposing pipeClient during switch"); }
+                try { eventClient?.Dispose(); } catch (Exception ex) { Logger.Debug(ex, "error disposing eventClient during switch"); }
+                pipeClient = null;
+                eventClient = null;
+                Connected = false;
+                ApplyDiscriminator(newDisc);
+            } finally {
+                SwitchInProgress = false;
+            }
+
+            await ConnectPipesAsync();
         }
 
         PipeSecurity CreateSystemIOPipeSecurity() {

--- a/ZitiDesktopEdge.Client/ServiceClient/TunnelInstanceDiscovery.cs
+++ b/ZitiDesktopEdge.Client/ServiceClient/TunnelInstanceDiscovery.cs
@@ -1,0 +1,250 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Newtonsoft.Json.Linq;
+using NLog;
+
+namespace ZitiDesktopEdge.ServiceClient {
+    /// <summary>
+    /// Discovers all ziti-edge-tunnel.exe instances running on the local machine by
+    /// enumerating named pipes of the form:
+    ///   \\.\pipe\ziti-edge-tunnel.sock              (default instance)
+    ///   \\.\pipe\ziti-edge-tunnel.sock.&lt;discriminator&gt;  (-P &lt;discriminator&gt; instance)
+    ///
+    /// For each matching pipe the discovery performs a best-effort "Status" probe to
+    /// pull TunName/IP/DNS. Instances are returned even if the probe fails so the UI
+    /// can present "something is listening there" to the user.
+    /// </summary>
+    public class TunnelInstanceDiscovery {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+        private const string DefaultPipeName = "ziti-edge-tunnel.sock";
+        private const string DefaultEventPipeName = "ziti-edge-tunnel-event.sock";
+        private static readonly Regex PipeNameRegex = new Regex(
+            @"^ziti-edge-tunnel\.sock(?:\.(.+))?$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        public class TunnelInstance {
+            public string Discriminator { get; set; }
+            public string DisplayLabel {
+                get { return string.IsNullOrEmpty(Discriminator) ? "default" : Discriminator; }
+            }
+            public string PipeName { get; set; }
+            public string EventPipeName { get; set; }
+            public string TunName { get; set; }
+            public string Ip { get; set; }
+            public string Dns { get; set; }
+
+            /// <summary>
+            /// True when this instance was discovered by enumerating live named
+            /// pipes. False for synthetic entries (e.g. the "default" row the
+            /// picker always shows even if the default pipe isn't active).
+            /// </summary>
+            public bool IsOnline { get; set; } = true;
+        }
+
+        /// <summary>
+        /// Construct a synthetic "default" TunnelInstance marked as offline.
+        /// Used by the picker so the default row is always visible even when
+        /// the default ziti-edge-tunnel isn't running — letting the user
+        /// come back to it after starting the service.
+        /// </summary>
+        public static TunnelInstance OfflineDefault() {
+            return new TunnelInstance {
+                Discriminator = null,
+                PipeName = "ziti-edge-tunnel.sock",
+                EventPipeName = "ziti-edge-tunnel-event.sock",
+                IsOnline = false,
+            };
+        }
+
+        /// <summary>
+        /// Enumerate all ziti-edge-tunnel instances currently running on the local
+        /// machine. Each discovered instance is probed in parallel with a short
+        /// timeout so total enumeration time is bounded by probeTimeoutMs rather
+        /// than N * probeTimeoutMs.
+        /// </summary>
+        public static async Task<IReadOnlyList<TunnelInstance>> EnumerateAsync(int probeTimeoutMs = 150, CancellationToken ct = default(CancellationToken)) {
+            List<TunnelInstance> instances = new List<TunnelInstance>();
+
+            string[] pipeEntries;
+            try {
+                // On Windows .NET Framework, Directory.GetFiles against \\.\pipe\
+                // returns the list of named pipes. Entries come back as full paths
+                // of the form \\.\pipe\<name>, so we extract just the name.
+                pipeEntries = Directory.GetFiles(@"\\.\pipe\");
+            } catch (Exception ex) {
+                Logger.Debug(ex, "Failed to enumerate named pipes at \\\\.\\pipe\\");
+                return instances;
+            }
+
+            foreach (string entry in pipeEntries) {
+                if (string.IsNullOrEmpty(entry)) continue;
+                string name = entry;
+                int lastSlash = name.LastIndexOf('\\');
+                if (lastSlash >= 0 && lastSlash < name.Length - 1) {
+                    name = name.Substring(lastSlash + 1);
+                }
+
+                Match m = PipeNameRegex.Match(name);
+                if (!m.Success) continue;
+
+                string discriminator = m.Groups[1].Success ? m.Groups[1].Value : null;
+
+                // Skip the event pipes - we only want the command pipes. The event
+                // pipe name contains "-event" which is not matched by our regex,
+                // but this guard is here defensively in case the regex is ever
+                // loosened.
+                if (!string.IsNullOrEmpty(discriminator) && discriminator.StartsWith("sock", StringComparison.OrdinalIgnoreCase)) {
+                    continue;
+                }
+
+                TunnelInstance inst = new TunnelInstance {
+                    Discriminator = discriminator,
+                    PipeName = string.IsNullOrEmpty(discriminator)
+                        ? DefaultPipeName
+                        : DefaultPipeName + "." + discriminator,
+                    EventPipeName = string.IsNullOrEmpty(discriminator)
+                        ? DefaultEventPipeName
+                        : DefaultEventPipeName + "." + discriminator,
+                };
+                instances.Add(inst);
+            }
+
+            // De-duplicate in case Directory.GetFiles returns an event pipe that
+            // somehow satisfied the regex (the event pipe name ends with
+            // -event.sock, which does not match ^ziti-edge-tunnel\.sock, so this
+            // is belt-and-braces only).
+            instances = instances
+                .GroupBy(i => i.PipeName, StringComparer.OrdinalIgnoreCase)
+                .Select(g => g.First())
+                .ToList();
+
+            if (instances.Count == 0) {
+                return instances;
+            }
+
+            Task[] probes = instances
+                .Select(i => ProbeAsync(i, probeTimeoutMs, ct))
+                .ToArray();
+            try {
+                await Task.WhenAll(probes).ConfigureAwait(false);
+            } catch (Exception ex) {
+                // Individual probe failures are swallowed inside ProbeAsync; this
+                // only trips for truly unexpected exceptions.
+                Logger.Debug(ex, "unexpected error while awaiting tunnel instance probes");
+            }
+
+            return instances;
+        }
+
+        private static async Task ProbeAsync(TunnelInstance inst, int probeTimeoutMs, CancellationToken ct) {
+            NamedPipeClientStream pipe = null;
+            try {
+                pipe = new NamedPipeClientStream(".", inst.PipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+
+                // NamedPipeClientStream.ConnectAsync in .NET Framework 4.8 exists,
+                // but it does not natively honor a cancellation token on the
+                // underlying connect. We wrap with a timeout Task so the probe is
+                // bounded. Any failure here just means "probe failed" - the
+                // instance still goes into the returned list.
+                Task connectTask = pipe.ConnectAsync(probeTimeoutMs);
+                Task delayTask = Task.Delay(probeTimeoutMs + 50, ct);
+                Task winner = await Task.WhenAny(connectTask, delayTask).ConfigureAwait(false);
+                if (winner != connectTask || !pipe.IsConnected) {
+                    Logger.Debug("probe: connect timed out for pipe '{0}'", inst.PipeName);
+                    return;
+                }
+                await connectTask.ConfigureAwait(false); // surface any connect exception
+
+                // Write the Status command.
+                byte[] payload = new UTF8Encoding(false).GetBytes("{\"Command\":\"Status\"}\n");
+                using (var cts = CancellationTokenSource.CreateLinkedTokenSource(ct)) {
+                    cts.CancelAfter(probeTimeoutMs);
+                    await pipe.WriteAsync(payload, 0, payload.Length, cts.Token).ConfigureAwait(false);
+                    await pipe.FlushAsync(cts.Token).ConfigureAwait(false);
+                }
+
+                // Read a single line back. Leave the stream open so the pipe is
+                // closed cleanly by the using below.
+                StreamReader reader = new StreamReader(pipe, new UTF8Encoding(false), false, 4096, true);
+                Task<string> readTask = reader.ReadLineAsync();
+                Task readTimeout = Task.Delay(probeTimeoutMs, ct);
+                Task readWinner = await Task.WhenAny(readTask, readTimeout).ConfigureAwait(false);
+                if (readWinner != readTask) {
+                    Logger.Debug("probe: read timed out for pipe '{0}'", inst.PipeName);
+                    return;
+                }
+
+                string line = await readTask.ConfigureAwait(false);
+                if (string.IsNullOrWhiteSpace(line)) {
+                    Logger.Debug("probe: empty response from pipe '{0}'", inst.PipeName);
+                    return;
+                }
+
+                try {
+                    // Status response envelope (ziti-tunnel-sdk-c):
+                    //   { Success, Error, Code, Data: { TunName, IpInfo: { Ip, DNS }, ... } }
+                    // Fields confirmed from
+                    //   lib/ziti-tunnel-cbs/include/ziti/ziti_tunnel_cbs.h:96-100
+                    //   programs/ziti-edge-tunnel/include/model/dtos.h:101-117
+                    JObject obj = JObject.Parse(line);
+                    JObject data = obj.GetValue("Data", StringComparison.OrdinalIgnoreCase) as JObject;
+                    if (data == null) {
+                        Logger.Debug("probe: status response for pipe '{0}' had no Data object. payload={1}", inst.PipeName, line);
+                        return;
+                    }
+
+                    inst.TunName = GetStringProp(data, "TunName");
+
+                    JObject ipInfo = data.GetValue("IpInfo", StringComparison.OrdinalIgnoreCase) as JObject;
+                    if (ipInfo != null) {
+                        inst.Ip = GetStringProp(ipInfo, "Ip");
+                        inst.Dns = GetStringProp(ipInfo, "DNS");
+                    }
+                } catch (Exception ex) {
+                    Logger.Debug(ex, "probe: failed to parse JSON response from pipe '{0}'. payload={1}", inst.PipeName, line);
+                }
+            } catch (OperationCanceledException) {
+                Logger.Debug("probe: canceled for pipe '{0}'", inst.PipeName);
+            } catch (Exception ex) {
+                Logger.Debug(ex, "probe: unexpected error for pipe '{0}'", inst.PipeName);
+            } finally {
+                try { pipe?.Dispose(); } catch { /* ignore */ }
+            }
+        }
+
+        private static string GetStringProp(JObject obj, string name) {
+            if (obj == null) return null;
+            JToken tok = obj.GetValue(name, StringComparison.OrdinalIgnoreCase);
+            if (tok == null || tok.Type == JTokenType.Null || tok.Type == JTokenType.Object || tok.Type == JTokenType.Array) {
+                return null;
+            }
+            string s = tok.ToString();
+            return string.IsNullOrEmpty(s) ? null : s;
+        }
+    }
+}

--- a/ZitiDesktopEdge.Client/ServiceClient/TunnelInstanceDiscovery.cs
+++ b/ZitiDesktopEdge.Client/ServiceClient/TunnelInstanceDiscovery.cs
@@ -95,7 +95,7 @@ namespace ZitiDesktopEdge.ServiceClient {
                 // On Windows .NET Framework, Directory.GetFiles against \\.\pipe\
                 // returns the list of named pipes. Entries come back as full paths
                 // of the form \\.\pipe\<name>, so we extract just the name.
-                pipeEntries = Directory.GetFiles(@"\\.\pipe\");
+                pipeEntries = Directory.GetFiles(@"\\.\pipe\", "ziti*");
             } catch (Exception ex) {
                 Logger.Debug(ex, "Failed to enumerate named pipes at \\\\.\\pipe\\");
                 return instances;

--- a/ZitiDesktopEdge.Client/ZitiDesktopEdge.Client.csproj
+++ b/ZitiDesktopEdge.Client/ZitiDesktopEdge.Client.csproj
@@ -75,6 +75,7 @@
     <Compile Include="ServiceClient\DataClient.cs" />
     <Compile Include="DataStructures\DataStructures.cs" />
     <Compile Include="ServiceClient\MonitorClient.cs" />
+    <Compile Include="ServiceClient\TunnelInstanceDiscovery.cs" />
     <Compile Include="Utility\GithubAPI.cs" />
     <Compile Include="Utility\UpgradeSentinel.cs" />
   </ItemGroup>


### PR DESCRIPTION
adds a key acceleration (ctrl-shift-t) to pick which ziti edge tunnel should be targetted by the UI for testing