### PR TITLE
Improve feedback collection

### DIFF
--- a/DesktopEdge/MainWindow.xaml
+++ b/DesktopEdge/MainWindow.xaml
@@ -481,7 +481,7 @@
                 <Grid.RowDefinitions>
                     <RowDefinition Height="*"></RowDefinition>
                     <RowDefinition Height="60"></RowDefinition>
-                    <RowDefinition Height="40"></RowDefinition>
+                    <RowDefinition Height="80"></RowDefinition>
                     <RowDefinition Height="10"></RowDefinition>
                     <RowDefinition Height="*"></RowDefinition>
                 </Grid.RowDefinitions>

--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -757,6 +757,7 @@ namespace ZitiDesktopEdge {
             monitorClient.OnClientConnected += MonitorClient_OnClientConnected;
             monitorClient.OnNotificationEvent += MonitorClient_OnInstallationNotificationEvent;
             monitorClient.OnServiceStatusEvent += MonitorClient_OnServiceStatusEvent;
+            monitorClient.OnCaptureFeedbackProgressEvent += MonitorClient_OnCaptureFeedbackProgressEvent;
             monitorClient.OnShutdownEvent += MonitorClient_OnShutdownEvent;
             monitorClient.OnCommunicationError += MonitorClient_OnCommunicationError;
             monitorClient.OnReconnectFailure += MonitorClient_OnReconnectFailure;
@@ -1035,6 +1036,19 @@ namespace ZitiDesktopEdge {
             } catch(Exception e) {
                 logger.Error("SetAutomaticUpdateEnabled: {0}", e);
             }
+        }
+
+        private void MonitorClient_OnCaptureFeedbackProgressEvent(object sender, MonitorServiceStatusEvent evt) {
+            if (evt == null || string.IsNullOrEmpty(evt.Message)) return;
+            this.Dispatcher.Invoke(() => {
+                if (LoadingScreen.Visibility == Visibility.Visible) {
+                    string current = MainMenu?.LogLevel ?? "";
+                    string level = string.IsNullOrEmpty(current) ? "UNKNOWN" : current.ToUpper();
+                    bool isVerbose = current == "trace" || current == "verbose" || current == "debug";
+                    string warning = isVerbose ? " (may take several minutes)" : "";
+                    LoadingDetails.Text = $"Log level: {level}{warning}\n{evt.Message}";
+                }
+            });
         }
 
         private void MonitorClient_OnInstallationNotificationEvent(object sender, InstallationNotificationEvent evt) {

--- a/DesktopEdge/Views/Screens/MainMenu.xaml.cs
+++ b/DesktopEdge/Views/Screens/MainMenu.xaml.cs
@@ -375,7 +375,14 @@ namespace ZitiDesktopEdge {
 
         async public void CollectFeedbackLogs(object sender, MouseButtonEventArgs e) {
             try {
-                MainWindow.ShowLoad("Collecting Information", "Please wait while we run some commands\nand collect some diagnostic information");
+                logger.Info("Feedback collection started");
+
+                string exeLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                string logLocation = Path.Combine(exeLocation, "logs");
+                string serviceLogsLocation = Path.Combine(logLocation, "service");
+
+                string statusMessage = buildFeedbackStatusMessage(logLocation);
+                MainWindow.ShowLoad("Collecting Information", statusMessage);
 
                 System.Text.StringBuilder sb = new System.Text.StringBuilder();
                 sb.Append("Logs collected at : " + DateTime.Now.ToString());
@@ -411,6 +418,23 @@ namespace ZitiDesktopEdge {
                 MainWindow.ShowError("Could Not Collect Feedback", "The monitor service is offline");
             }
             MainWindow.HideLoad();
+        }
+
+        private string buildFeedbackStatusMessage(string logLocation) {
+            string level = string.IsNullOrEmpty(this.LogLevel) ? "unknown" : this.LogLevel.ToUpper();
+            long totalBytes = 0;
+            try {
+                foreach (FileInfo file in new DirectoryInfo(logLocation).GetFiles("*.*", SearchOption.AllDirectories)) {
+                    if (file.Name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase)) continue;
+                    totalBytes += file.Length;
+                }
+            } catch (Exception ex) {
+                logger.Warn(ex, "could not size {0}", logLocation);
+            }
+            string size = ByteFormat.Format(totalBytes);
+            bool isVerbose = this.LogLevel == "trace" || this.LogLevel == "verbose" || this.LogLevel == "debug";
+            string warning = isVerbose ? "\nVerbose logging may take several minutes." : "";
+            return $"Log level: {level} | ~{size} of logs{warning}";
         }
 
         private void ShowSupport(object sender, MouseButtonEventArgs e) {

--- a/DesktopEdge/Views/Screens/MainMenu.xaml.cs
+++ b/DesktopEdge/Views/Screens/MainMenu.xaml.cs
@@ -392,9 +392,6 @@ namespace ZitiDesktopEdge {
 
                 var dataClient = (DataClient)Application.Current.Properties["ServiceClient"];
 
-                string exeLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-                string logLocation = Path.Combine(exeLocation, "logs");
-                string serviceLogsLocation = Path.Combine(logLocation, "service");
                 await dataClient.zitiDump(serviceLogsLocation);
 
                 var monitorClient = (MonitorClient)Application.Current.Properties["MonitorClient"];
@@ -406,15 +403,16 @@ namespace ZitiDesktopEdge {
                     return;
                 }
                 string pathToLogs = resp.Message;
-                logger.Info("Log files found at : {0}", resp.Message);
+                logger.Info("Feedback collection completed: {0}", pathToLogs);
                 string args = string.Format("/Select, \"{0}\"", pathToLogs);
 
                 ProcessStartInfo pfi = new ProcessStartInfo("Explorer.exe", args);
                 Process.Start(pfi);
-            } catch (MonitorServiceException) {
+            } catch (MonitorServiceException ex) {
+                logger.Warn("Feedback collection aborted: {0}", ex.Message);
                 MainWindow.ShowError("Could Not Collect Feedback", "The monitor service is offline");
             } catch (Exception ex) {
-                logger.Warn(ex, "An unexpected error has occurred when submitting feedback? {0}", ex.Message);
+                logger.Warn(ex, "Feedback collection failed: {0}", ex.Message);
                 MainWindow.ShowError("Could Not Collect Feedback", "The monitor service is offline");
             }
             MainWindow.HideLoad();

--- a/DesktopEdge/Views/Screens/MainMenu.xaml.cs
+++ b/DesktopEdge/Views/Screens/MainMenu.xaml.cs
@@ -61,6 +61,7 @@ namespace ZitiDesktopEdge {
         public string LogLevel = "";
         private string appVersion = null;
         public double MainHeight = 500;
+        private bool _isCapturingFeedback;
 
         private ZDEWViewState state;
 
@@ -374,6 +375,17 @@ namespace ZitiDesktopEdge {
         }
 
         async public void CollectFeedbackLogs(object sender, MouseButtonEventArgs e) {
+            if (_isCapturingFeedback) {
+                logger.Info("Feedback collection already in progress - ignoring duplicate click");
+                return;
+            }
+            MonitorClient mc = (MonitorClient)Application.Current.Properties["MonitorClient"];
+            if (mc != null && mc.IsServiceCapturingFeedback) {
+                logger.Info("Service still emitting CaptureFeedback heartbeats - previous capture not yet finished");
+                MainWindow.ShowError("Feedback unavailable", "A previous feedback collection is still running. Check logs for progress, or wait for it to finish.");
+                return;
+            }
+            _isCapturingFeedback = true;
             try {
                 logger.Info("Feedback collection started");
 
@@ -383,12 +395,6 @@ namespace ZitiDesktopEdge {
 
                 string statusMessage = buildFeedbackStatusMessage(logLocation);
                 MainWindow.ShowLoad("Collecting Information", statusMessage);
-
-                System.Text.StringBuilder sb = new System.Text.StringBuilder();
-                sb.Append("Logs collected at : " + DateTime.Now.ToString());
-                sb.Append(". client version : " + appVersion);
-
-                string timestamp = DateTime.Now.ToFileTime().ToString();
 
                 var dataClient = (DataClient)Application.Current.Properties["ServiceClient"];
 
@@ -410,12 +416,14 @@ namespace ZitiDesktopEdge {
                 Process.Start(pfi);
             } catch (MonitorServiceException ex) {
                 logger.Warn("Feedback collection aborted: {0}", ex.Message);
-                MainWindow.ShowError("Could Not Collect Feedback", "The monitor service is offline");
+                MainWindow.ShowError("Could Not Collect Feedback", ex.Message);
             } catch (Exception ex) {
                 logger.Warn(ex, "Feedback collection failed: {0}", ex.Message);
                 MainWindow.ShowError("Could Not Collect Feedback", "The monitor service is offline");
+            } finally {
+                _isCapturingFeedback = false;
+                MainWindow.HideLoad();
             }
-            MainWindow.HideLoad();
         }
 
         private string buildFeedbackStatusMessage(string logLocation) {

--- a/DesktopEdge/Views/Screens/MainMenu.xaml.cs
+++ b/DesktopEdge/Views/Screens/MainMenu.xaml.cs
@@ -61,7 +61,6 @@ namespace ZitiDesktopEdge {
         public string LogLevel = "";
         private string appVersion = null;
         public double MainHeight = 500;
-        private bool _isCapturingFeedback;
 
         private ZDEWViewState state;
 
@@ -375,26 +374,20 @@ namespace ZitiDesktopEdge {
         }
 
         async public void CollectFeedbackLogs(object sender, MouseButtonEventArgs e) {
-            if (_isCapturingFeedback) {
-                logger.Info("Feedback collection already in progress - ignoring duplicate click");
-                return;
-            }
             MonitorClient mc = (MonitorClient)Application.Current.Properties["MonitorClient"];
             if (mc != null && mc.IsServiceCapturingFeedback) {
-                logger.Info("Service still emitting CaptureFeedback heartbeats - previous capture not yet finished");
-                MainWindow.ShowError("Feedback unavailable", "A previous feedback collection is still running. Check logs for progress, or wait for it to finish.");
+                logger.Debug("Service still emitting CaptureFeedback heartbeats - previous capture not yet finished");
+                await MainWindow.ShowBlurbAsync("Feedback in progress", "A previous feedback collection is still running.");
                 return;
             }
-            _isCapturingFeedback = true;
             try {
-                logger.Info("Feedback collection started");
+                logger.Debug("Feedback collection started");
 
                 string exeLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
                 string logLocation = Path.Combine(exeLocation, "logs");
                 string serviceLogsLocation = Path.Combine(logLocation, "service");
 
-                string statusMessage = buildFeedbackStatusMessage(logLocation);
-                MainWindow.ShowLoad("Collecting Information", statusMessage);
+                MainWindow.ShowLoad("Collecting Information", "Please wait...");
 
                 var dataClient = (DataClient)Application.Current.Properties["ServiceClient"];
 
@@ -409,38 +402,20 @@ namespace ZitiDesktopEdge {
                     return;
                 }
                 string pathToLogs = resp.Message;
-                logger.Info("Feedback collection completed: {0}", pathToLogs);
+                logger.Info("Feedback collection completed at {0}: {1}", DateTime.Now, pathToLogs);
                 string args = string.Format("/Select, \"{0}\"", pathToLogs);
 
                 ProcessStartInfo pfi = new ProcessStartInfo("Explorer.exe", args);
                 Process.Start(pfi);
             } catch (MonitorServiceException ex) {
-                logger.Warn("Feedback collection aborted: {0}", ex.Message);
+                logger.Error("Feedback collection aborted: {0}", ex.Message);
                 MainWindow.ShowError("Could Not Collect Feedback", ex.Message);
             } catch (Exception ex) {
-                logger.Warn(ex, "Feedback collection failed: {0}", ex.Message);
+                logger.Error(ex, "Feedback collection failed: {0}", ex.Message);
                 MainWindow.ShowError("Could Not Collect Feedback", "The monitor service is offline");
             } finally {
-                _isCapturingFeedback = false;
                 MainWindow.HideLoad();
             }
-        }
-
-        private string buildFeedbackStatusMessage(string logLocation) {
-            string level = string.IsNullOrEmpty(this.LogLevel) ? "unknown" : this.LogLevel.ToUpper();
-            long totalBytes = 0;
-            try {
-                foreach (FileInfo file in new DirectoryInfo(logLocation).GetFiles("*.*", SearchOption.AllDirectories)) {
-                    if (file.Name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase)) continue;
-                    totalBytes += file.Length;
-                }
-            } catch (Exception ex) {
-                logger.Warn(ex, "could not size {0}", logLocation);
-            }
-            string size = ByteFormat.Format(totalBytes);
-            bool isVerbose = this.LogLevel == "trace" || this.LogLevel == "verbose" || this.LogLevel == "debug";
-            string warning = isVerbose ? "\nVerbose logging may take several minutes." : "";
-            return $"Log level: {level} | ~{size} of logs{warning}";
         }
 
         private void ShowSupport(object sender, MouseButtonEventArgs e) {

--- a/ZitiDesktopEdge.Client/ServiceClient/MonitorClient.cs
+++ b/ZitiDesktopEdge.Client/ServiceClient/MonitorClient.cs
@@ -152,7 +152,29 @@ namespace ZitiDesktopEdge.ServiceClient {
         async public Task<MonitorServiceStatusEvent> CaptureLogsAsync() {
             ActionEvent action = new ActionEvent() { Op = "CaptureLogs", Action = "Normal" };
             await sendMonitorClientAsync(action);
-            return await readMonitorClientAsync<MonitorServiceStatusEvent>(ipcReader, TimeSpan.FromSeconds(60));
+
+            DateTime lastProgressTime = DateTime.UtcNow;
+            EventHandler<MonitorServiceStatusEvent> heartbeat = (s, e) => lastProgressTime = DateTime.UtcNow;
+            OnCaptureFeedbackProgressEvent += heartbeat;
+
+            try {
+                Task<MonitorServiceStatusEvent> readTask = readMonitorClientAsync<MonitorServiceStatusEvent>(ipcReader, Timeout.InfiniteTimeSpan);
+                TimeSpan stallThreshold = TimeSpan.FromSeconds(60);
+
+                while (true) {
+                    Task completed = await Task.WhenAny(readTask, Task.Delay(5000));
+                    if (completed == readTask) {
+                        return await readTask;
+                    }
+                    if (DateTime.UtcNow - lastProgressTime > stallThreshold) {
+                        string error = $"Feedback collection stalled (no progress for {stallThreshold.TotalSeconds}s).";
+                        Logger.Error(error);
+                        throw new MonitorServiceException(error);
+                    }
+                }
+            } finally {
+                OnCaptureFeedbackProgressEvent -= heartbeat;
+            }
         }
 
         async public Task<SvcResponse> SetLogLevelAsync(string level) {

--- a/ZitiDesktopEdge.Client/ServiceClient/MonitorClient.cs
+++ b/ZitiDesktopEdge.Client/ServiceClient/MonitorClient.cs
@@ -52,11 +52,9 @@ namespace ZitiDesktopEdge.ServiceClient {
         public event EventHandler<InstallationNotificationEvent> OnNotificationEvent;
         public event EventHandler<MonitorServiceStatusEvent> OnCaptureFeedbackProgressEvent;
 
-        private static readonly TimeSpan FeedbackHeartbeatStaleAfter = TimeSpan.FromSeconds(10);
-
         public DateTime LastFeedbackHeartbeat { get; private set; } = DateTime.MinValue;
 
-        public bool IsServiceCapturingFeedback => DateTime.UtcNow - LastFeedbackHeartbeat < FeedbackHeartbeatStaleAfter;
+        public bool IsServiceCapturingFeedback => (DateTime.UtcNow - LastFeedbackHeartbeat).TotalSeconds < 10;
 
         protected virtual void ServiceStatusEvent(MonitorServiceStatusEvent e) {
             OnServiceStatusEvent?.Invoke(this, e);

--- a/ZitiDesktopEdge.Client/ServiceClient/MonitorClient.cs
+++ b/ZitiDesktopEdge.Client/ServiceClient/MonitorClient.cs
@@ -50,6 +50,7 @@ namespace ZitiDesktopEdge.ServiceClient {
 
         public event EventHandler<MonitorServiceStatusEvent> OnServiceStatusEvent;
         public event EventHandler<InstallationNotificationEvent> OnNotificationEvent;
+        public event EventHandler<MonitorServiceStatusEvent> OnCaptureFeedbackProgressEvent;
 
         protected virtual void ServiceStatusEvent(MonitorServiceStatusEvent e) {
             OnServiceStatusEvent?.Invoke(this, e);
@@ -57,6 +58,10 @@ namespace ZitiDesktopEdge.ServiceClient {
 
         protected virtual void InstallationNotificationEvent(InstallationNotificationEvent e) {
             OnNotificationEvent?.Invoke(this, e);
+        }
+
+        protected virtual void CaptureFeedbackProgressEvent(MonitorServiceStatusEvent e) {
+            OnCaptureFeedbackProgressEvent?.Invoke(this, e);
         }
 
         public MonitorClient(string id) : base(id) {
@@ -84,6 +89,9 @@ namespace ZitiDesktopEdge.ServiceClient {
                 case "Notification":
                     var instEvt = serializer.Deserialize<InstallationNotificationEvent>(new JsonTextReader(new StringReader(line)));
                     InstallationNotificationEvent(instEvt);
+                    break;
+                case "CaptureFeedbackProgress":
+                    CaptureFeedbackProgressEvent(evt);
                     break;
                 default:
                     ServiceStatusEvent(evt);

--- a/ZitiDesktopEdge.Client/ServiceClient/MonitorClient.cs
+++ b/ZitiDesktopEdge.Client/ServiceClient/MonitorClient.cs
@@ -52,6 +52,12 @@ namespace ZitiDesktopEdge.ServiceClient {
         public event EventHandler<InstallationNotificationEvent> OnNotificationEvent;
         public event EventHandler<MonitorServiceStatusEvent> OnCaptureFeedbackProgressEvent;
 
+        private static readonly TimeSpan FeedbackHeartbeatStaleAfter = TimeSpan.FromSeconds(10);
+
+        public DateTime LastFeedbackHeartbeat { get; private set; } = DateTime.MinValue;
+
+        public bool IsServiceCapturingFeedback => DateTime.UtcNow - LastFeedbackHeartbeat < FeedbackHeartbeatStaleAfter;
+
         protected virtual void ServiceStatusEvent(MonitorServiceStatusEvent e) {
             OnServiceStatusEvent?.Invoke(this, e);
         }
@@ -61,6 +67,7 @@ namespace ZitiDesktopEdge.ServiceClient {
         }
 
         protected virtual void CaptureFeedbackProgressEvent(MonitorServiceStatusEvent e) {
+            LastFeedbackHeartbeat = DateTime.UtcNow;
             OnCaptureFeedbackProgressEvent?.Invoke(this, e);
         }
 
@@ -153,28 +160,15 @@ namespace ZitiDesktopEdge.ServiceClient {
             ActionEvent action = new ActionEvent() { Op = "CaptureLogs", Action = "Normal" };
             await sendMonitorClientAsync(action);
 
-            DateTime lastProgressTime = DateTime.UtcNow;
-            EventHandler<MonitorServiceStatusEvent> heartbeat = (s, e) => lastProgressTime = DateTime.UtcNow;
-            OnCaptureFeedbackProgressEvent += heartbeat;
-
-            try {
-                Task<MonitorServiceStatusEvent> readTask = readMonitorClientAsync<MonitorServiceStatusEvent>(ipcReader, Timeout.InfiniteTimeSpan);
-                TimeSpan stallThreshold = TimeSpan.FromSeconds(60);
-
-                while (true) {
-                    Task completed = await Task.WhenAny(readTask, Task.Delay(5000));
-                    if (completed == readTask) {
-                        return await readTask;
-                    }
-                    if (DateTime.UtcNow - lastProgressTime > stallThreshold) {
-                        string error = $"Feedback collection stalled (no progress for {stallThreshold.TotalSeconds}s).";
-                        Logger.Error(error);
-                        throw new MonitorServiceException(error);
-                    }
+            LastFeedbackHeartbeat = DateTime.UtcNow;
+            Task<MonitorServiceStatusEvent> readTask = readMonitorClientAsync<MonitorServiceStatusEvent>(ipcReader, TimeSpan.FromMinutes(30));
+            while (!readTask.IsCompleted) {
+                await Task.WhenAny(readTask, Task.Delay(2000));
+                if (!IsServiceCapturingFeedback) {
+                    throw new MonitorServiceException("Feedback collection stopped responding.");
                 }
-            } finally {
-                OnCaptureFeedbackProgressEvent -= heartbeat;
             }
+            return await readTask;
         }
 
         async public Task<SvcResponse> SetLogLevelAsync(string level) {

--- a/ZitiDesktopEdge.Client/Utility/ByteFormat.cs
+++ b/ZitiDesktopEdge.Client/Utility/ByteFormat.cs
@@ -1,0 +1,30 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+namespace ZitiDesktopEdge.Utility {
+    public static class ByteFormat {
+        public static string Format(long bytes) {
+            string[] suffixes = { "B", "KB", "MB", "GB", "TB" };
+            double value = bytes;
+            int index = 0;
+            while (value >= 1024 && index < suffixes.Length - 1) {
+                value = value / 1024;
+                index++;
+            }
+            return value.ToString("0.0") + " " + suffixes[index];
+        }
+    }
+}

--- a/ZitiDesktopEdge.Client/ZitiDesktopEdge.Client.csproj
+++ b/ZitiDesktopEdge.Client/ZitiDesktopEdge.Client.csproj
@@ -75,6 +75,7 @@
     <Compile Include="ServiceClient\DataClient.cs" />
     <Compile Include="DataStructures\DataStructures.cs" />
     <Compile Include="ServiceClient\MonitorClient.cs" />
+    <Compile Include="Utility\ByteFormat.cs" />
     <Compile Include="Utility\GithubAPI.cs" />
     <Compile Include="Utility\UpgradeSentinel.cs" />
   </ItemGroup>

--- a/ZitiUpdateService/UpdateService.cs
+++ b/ZitiUpdateService/UpdateService.cs
@@ -276,12 +276,25 @@ namespace ZitiUpdateService {
             }
         }
 
+        private const int FeedbackHeartbeatIntervalMs = 5000;
+        private string _currentFeedbackPhase = "";
+
+        private void setFeedbackPhase(string phase) {
+            Logger.Info("Feedback phase: {0}", phase);
+            _currentFeedbackPhase = phase;
+            sendCaptureFeedbackProgress(phase);
+        }
+
         private string CaptureLogs() {
+            _currentFeedbackPhase = "Starting...";
+
+            System.Timers.Timer heartbeat = new System.Timers.Timer(FeedbackHeartbeatIntervalMs);
+            heartbeat.Elapsed += (s, e) => sendCaptureFeedbackProgress(_currentFeedbackPhase);
+            heartbeat.Start();
+
             try {
                 string logLocation = Path.Combine(exeLocation, "logs");
                 string destinationLocation = Path.Combine(exeLocation, "temp");
-                string serviceLogsLocation = Path.Combine(logLocation, "service");
-                string serviceLogsDest = Path.Combine(destinationLocation, "service");
 
                 Logger.Debug("removing leftover temp folder: {0}", destinationLocation);
                 try {
@@ -292,71 +305,45 @@ namespace ZitiUpdateService {
 
                 Directory.CreateDirectory(destinationLocation);
 
+                // Clone directory structure for zip
                 Logger.Debug("copying all directories from: {0}", logLocation);
                 foreach (string dirPath in Directory.GetDirectories(logLocation, "*", SearchOption.AllDirectories)) {
                     Directory.CreateDirectory(dirPath.Replace(logLocation, destinationLocation));
                 }
 
+                // Get size of files to copy/zip for UI
                 long totalBytes = 0;
                 foreach (string filePath in Directory.GetFiles(logLocation, "*.*", SearchOption.AllDirectories)) {
-                    if (!filePath.EndsWith(".zip")) totalBytes += new FileInfo(filePath).Length;
+                    if (!filePath.EndsWith(".zip") && !isSymlink(filePath)) {
+                        totalBytes += new FileInfo(filePath).Length;
+                    }
                 }
-                long bytesProcessed = 0;
+                string sizeText = ByteFormat.Format(totalBytes);
 
+                setFeedbackPhase($"Copying log files (~{sizeText})");
                 Logger.Debug("copying all non-zip files from: {0}", logLocation);
                 foreach (string newPath in Directory.GetFiles(logLocation, "*.*", SearchOption.AllDirectories)) {
-                    if (!newPath.EndsWith(".zip")) {
-                        sendCaptureFeedbackProgress("Preparing... " + ByteFormat.Format(bytesProcessed) + " of " + ByteFormat.Format(totalBytes));
+                    if (!newPath.EndsWith(".zip") && !isSymlink(newPath)) {
+                        Logger.Debug("copying file: {0}", newPath);
                         File.Copy(newPath, newPath.Replace(logLocation, destinationLocation), true);
-                        bytesProcessed += new FileInfo(newPath).Length;
                     }
                 }
 
-                Logger.Debug("copying service files from: {0} to {1}", serviceLogsLocation, serviceLogsDest);
-                Directory.CreateDirectory(serviceLogsDest);
-                foreach (string newPath in Directory.GetFiles(serviceLogsLocation, "*.*", SearchOption.TopDirectoryOnly)) {
-                    if (newPath.EndsWith(".log") || newPath.Contains("config.json")) {
-                        sendCaptureFeedbackProgress("Copying log: " + Path.GetFileName(newPath));
-                        File.Copy(newPath, newPath.Replace(serviceLogsLocation, serviceLogsDest), true);
-                    }
-                }
-
-                sendCaptureFeedbackProgress("Collecting system info: ipconfig...");
+                setFeedbackPhase($"Collecting system info");
                 outputIpconfigInfo(destinationLocation);
-                sendCaptureFeedbackProgress("Collecting system info: systeminfo...");
                 outputSystemInfo(destinationLocation);
-                sendCaptureFeedbackProgress("Collecting system info: DNS cache...");
                 outputDnsCache(destinationLocation);
-                sendCaptureFeedbackProgress("Collecting system info: external IP...");
                 outputExternalIP(destinationLocation);
-                sendCaptureFeedbackProgress("Collecting system info: tasklist...");
                 outputTasklist(destinationLocation);
-                sendCaptureFeedbackProgress("Collecting system info: routes...");
                 outputRouteInfo(destinationLocation);
-                sendCaptureFeedbackProgress("Collecting system info: netstat...");
                 outputNetstatInfo(destinationLocation);
-                sendCaptureFeedbackProgress("Collecting system info: NRPT...");
                 outputNrpt(destinationLocation);
 
                 Task.Delay(500).Wait();
 
+                setFeedbackPhase($"Zipping log files (~{sizeText})");
                 string zipName = Path.Combine(logLocation, DateTime.Now.ToString("yyyy-MM-dd_HHmmss") + ".zip");
-
-                string[] filesToZip = Directory.GetFiles(destinationLocation, "*.*", SearchOption.AllDirectories);
-                long totalZipBytes = 0;
-                foreach (string filePath in filesToZip) totalZipBytes += new FileInfo(filePath).Length;
-                long zipBytesProcessed = 0;
-
-                using (ZipArchive zip = ZipFile.Open(zipName, ZipArchiveMode.Create)) {
-                    foreach (string filePath in filesToZip) {
-                        sendCaptureFeedbackProgress("Compressing... " + ByteFormat.Format(zipBytesProcessed) + " of " + ByteFormat.Format(totalZipBytes));
-                        string entryName = filePath.Substring(destinationLocation.Length)
-                            .TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-                            .Replace(Path.DirectorySeparatorChar, '/');
-                        zip.CreateEntryFromFile(filePath, entryName, CompressionLevel.Optimal);
-                        zipBytesProcessed += new FileInfo(filePath).Length;
-                    }
-                }
+                ZipFile.CreateFromDirectory(destinationLocation, zipName);
 
                 Logger.Debug("cleaning up temp folder: {0}", destinationLocation);
                 try {
@@ -368,11 +355,21 @@ namespace ZitiUpdateService {
             } catch (Exception ex) {
                 Logger.Error(ex, "Unexpected error in generating system files {0}", ex.Message);
                 return null;
+            } finally {
+                heartbeat.Stop();
+                heartbeat.Dispose();
+            }
+        }
+
+        private static bool isSymlink(string path) {
+            try {
+                return (File.GetAttributes(path) & FileAttributes.ReparsePoint) != 0;
+            } catch {
+                return false;
             }
         }
 
         private static void sendCaptureFeedbackProgress(string message) {
-            Logger.Info(message);
             MonitorServiceStatusEvent evt = new MonitorServiceStatusEvent();
             evt.Type = "CaptureFeedbackProgress";
             evt.Message = message;

--- a/ZitiUpdateService/UpdateService.cs
+++ b/ZitiUpdateService/UpdateService.cs
@@ -276,19 +276,13 @@ namespace ZitiUpdateService {
             }
         }
 
-        private const int FeedbackHeartbeatIntervalMs = 5000;
+        private const int _feedbackHeartbeatIntervalMs = 5000;
         private string _currentFeedbackPhase = "";
 
-        private void setFeedbackPhase(string phase) {
-            Logger.Info("Feedback phase: {0}", phase);
-            _currentFeedbackPhase = phase;
-            sendCaptureFeedbackProgress(phase);
-        }
-
         private string CaptureLogs() {
-            _currentFeedbackPhase = "Starting...";
+            sendCaptureFeedbackProgress("Starting...");
 
-            System.Timers.Timer heartbeat = new System.Timers.Timer(FeedbackHeartbeatIntervalMs);
+            System.Timers.Timer heartbeat = new System.Timers.Timer(_feedbackHeartbeatIntervalMs);
             heartbeat.Elapsed += (s, e) => sendCaptureFeedbackProgress(_currentFeedbackPhase);
             heartbeat.Start();
 
@@ -320,7 +314,7 @@ namespace ZitiUpdateService {
                 }
                 string sizeText = ByteFormat.Format(totalBytes);
 
-                setFeedbackPhase($"Copying log files (~{sizeText})");
+                sendCaptureFeedbackProgress($"Copying log files (~{sizeText})");
                 Logger.Debug("copying all non-zip files from: {0}", logLocation);
                 foreach (string newPath in Directory.GetFiles(logLocation, "*.*", SearchOption.AllDirectories)) {
                     if (!newPath.EndsWith(".zip") && !isSymlink(newPath)) {
@@ -329,7 +323,7 @@ namespace ZitiUpdateService {
                     }
                 }
 
-                setFeedbackPhase($"Collecting system info");
+                sendCaptureFeedbackProgress($"Collecting system info");
                 outputIpconfigInfo(destinationLocation);
                 outputSystemInfo(destinationLocation);
                 outputDnsCache(destinationLocation);
@@ -341,7 +335,7 @@ namespace ZitiUpdateService {
 
                 Task.Delay(500).Wait();
 
-                setFeedbackPhase($"Zipping log files (~{sizeText})");
+                sendCaptureFeedbackProgress($"Zipping log files (~{sizeText})");
                 string zipName = Path.Combine(logLocation, DateTime.Now.ToString("yyyy-MM-dd_HHmmss") + ".zip");
                 ZipFile.CreateFromDirectory(destinationLocation, zipName);
 
@@ -369,10 +363,14 @@ namespace ZitiUpdateService {
             }
         }
 
-        private static void sendCaptureFeedbackProgress(string message) {
+        private void sendCaptureFeedbackProgress(string phase) {
+            if (phase != _currentFeedbackPhase) {
+                Logger.Info("Feedback phase: {0}", phase);
+                _currentFeedbackPhase = phase;
+            }
             MonitorServiceStatusEvent evt = new MonitorServiceStatusEvent();
             evt.Type = "CaptureFeedbackProgress";
-            evt.Message = message;
+            evt.Message = phase;
             EventRegistry.SendEventToConsumers(evt);
         }
 

--- a/ZitiUpdateService/UpdateService.cs
+++ b/ZitiUpdateService/UpdateService.cs
@@ -297,10 +297,18 @@ namespace ZitiUpdateService {
                     Directory.CreateDirectory(dirPath.Replace(logLocation, destinationLocation));
                 }
 
+                long totalBytes = 0;
+                foreach (string filePath in Directory.GetFiles(logLocation, "*.*", SearchOption.AllDirectories)) {
+                    if (!filePath.EndsWith(".zip")) totalBytes += new FileInfo(filePath).Length;
+                }
+                long bytesProcessed = 0;
+
                 Logger.Debug("copying all non-zip files from: {0}", logLocation);
                 foreach (string newPath in Directory.GetFiles(logLocation, "*.*", SearchOption.AllDirectories)) {
                     if (!newPath.EndsWith(".zip")) {
+                        sendCaptureFeedbackProgress("Preparing... " + ByteFormat.Format(bytesProcessed) + " of " + ByteFormat.Format(totalBytes));
                         File.Copy(newPath, newPath.Replace(logLocation, destinationLocation), true);
+                        bytesProcessed += new FileInfo(newPath).Length;
                     }
                 }
 
@@ -308,24 +316,47 @@ namespace ZitiUpdateService {
                 Directory.CreateDirectory(serviceLogsDest);
                 foreach (string newPath in Directory.GetFiles(serviceLogsLocation, "*.*", SearchOption.TopDirectoryOnly)) {
                     if (newPath.EndsWith(".log") || newPath.Contains("config.json")) {
-                        Logger.Debug("copying service log: {0}", newPath);
+                        sendCaptureFeedbackProgress("Copying log: " + Path.GetFileName(newPath));
                         File.Copy(newPath, newPath.Replace(serviceLogsLocation, serviceLogsDest), true);
                     }
                 }
 
+                sendCaptureFeedbackProgress("Collecting system info: ipconfig...");
                 outputIpconfigInfo(destinationLocation);
+                sendCaptureFeedbackProgress("Collecting system info: systeminfo...");
                 outputSystemInfo(destinationLocation);
+                sendCaptureFeedbackProgress("Collecting system info: DNS cache...");
                 outputDnsCache(destinationLocation);
+                sendCaptureFeedbackProgress("Collecting system info: external IP...");
                 outputExternalIP(destinationLocation);
+                sendCaptureFeedbackProgress("Collecting system info: tasklist...");
                 outputTasklist(destinationLocation);
+                sendCaptureFeedbackProgress("Collecting system info: routes...");
                 outputRouteInfo(destinationLocation);
+                sendCaptureFeedbackProgress("Collecting system info: netstat...");
                 outputNetstatInfo(destinationLocation);
+                sendCaptureFeedbackProgress("Collecting system info: NRPT...");
                 outputNrpt(destinationLocation);
 
                 Task.Delay(500).Wait();
 
                 string zipName = Path.Combine(logLocation, DateTime.Now.ToString("yyyy-MM-dd_HHmmss") + ".zip");
-                ZipFile.CreateFromDirectory(destinationLocation, zipName);
+
+                string[] filesToZip = Directory.GetFiles(destinationLocation, "*.*", SearchOption.AllDirectories);
+                long totalZipBytes = 0;
+                foreach (string filePath in filesToZip) totalZipBytes += new FileInfo(filePath).Length;
+                long zipBytesProcessed = 0;
+
+                using (ZipArchive zip = ZipFile.Open(zipName, ZipArchiveMode.Create)) {
+                    foreach (string filePath in filesToZip) {
+                        sendCaptureFeedbackProgress("Compressing... " + ByteFormat.Format(zipBytesProcessed) + " of " + ByteFormat.Format(totalZipBytes));
+                        string entryName = filePath.Substring(destinationLocation.Length)
+                            .TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                            .Replace(Path.DirectorySeparatorChar, '/');
+                        zip.CreateEntryFromFile(filePath, entryName, CompressionLevel.Optimal);
+                        zipBytesProcessed += new FileInfo(filePath).Length;
+                    }
+                }
 
                 Logger.Debug("cleaning up temp folder: {0}", destinationLocation);
                 try {
@@ -338,6 +369,14 @@ namespace ZitiUpdateService {
                 Logger.Error(ex, "Unexpected error in generating system files {0}", ex.Message);
                 return null;
             }
+        }
+
+        private static void sendCaptureFeedbackProgress(string message) {
+            Logger.Info(message);
+            MonitorServiceStatusEvent evt = new MonitorServiceStatusEvent();
+            evt.Type = "CaptureFeedbackProgress";
+            evt.Message = message;
+            EventRegistry.SendEventToConsumers(evt);
         }
 
         private void outputIpconfigInfo(string destinationFolder) {

--- a/upcoming-release-notes.md
+++ b/upcoming-release-notes.md
@@ -1,15 +1,14 @@
-# Release 2.10.7.0
+# Next Release
 ## What's New
-* updated to [ziti-edge-tunnel v1.16.1](https://github.com/openziti/ziti-tunnel-sdk-c/releases/tag/v1.16.1)
+n/a
 
 ## Bugs fixed
-n/a
+* [Issue 776](https://github.com/openziti/desktop-edge-win/issues/776) - Feedback collection no longer times out prematurely on large or verbose log bundles
+    * Progress dialog shows the current phase (copy, collect, zip) and bundle size
+    * Stall detection: if the service stops sending progress for 10 seconds the UI surfaces an error
+    * A notice is shown when feedback is requested while a previous collection is still in progress
+    * Error dialog reports the underlying error rather than always saying "monitor service is offline"
+    * Symlinked log files are skipped, and a duplicate ZET log copy step was removed
 
 ## Other changes
 n/a
-
-## Dependencies
-* ziti-tunneler: v1.16.1
-* ziti-sdk:      1.16.0
-* tlsuv:         v0.41.3[OpenSSL 3.6.1 27 Jan 2026]
-* tlsuv:         v0.41.3[win32crypto(CNG): ncrypt[1.0] ]


### PR DESCRIPTION
- The feedback dialog now shows what the service is doing (copying log files, collecting system info, zipping log files) and how big the bundle is
- If the service stops responding for 10 seconds, the UI shows an error
- The feedback button shows a blurb when clicked while a previous feedback collection is still running
- The error dialog now shows the actual error message instead of always saying "monitor service is offline"
- Symlinked log files are skipped
- Removed a duplicate copy step that was copying ZET logs twice
- Added log entries when feedback starts, finishes, or fails
- Added a small utility for formatting byte sizes as KB/MB/GB.
- Closes #776