### PR TITLE
Enroll to cert / token

### DIFF
--- a/DesktopEdge/MainWindow.xaml
+++ b/DesktopEdge/MainWindow.xaml
@@ -350,6 +350,22 @@
                 </Grid.ColumnDefinitions>
                 <Label Name="AddIdButton" Padding="0,0,0,0" Grid.Column="0" Margin="0,0,0,0" Content=""  Foreground="#0069FF" FontSize="12 " HorizontalAlignment="Center" VerticalAlignment="Center" ></Label>
             </Grid>
+            <Border x:Name="AlternateTunnelFooter"
+                    Visibility="Collapsed"
+                    Margin="14,0,14,10"
+                    Padding="10,6,10,6"
+                    CornerRadius="4"
+                    BorderThickness="1"
+                    BorderBrush="#4AC84A"
+                    Background="#1F2E23">
+                <TextBlock x:Name="AlternateTunnelFooterText"
+                           Foreground="#CDEFD1"
+                           FontFamily="Segoe UI"
+                           FontSize="11"
+                           TextWrapping="Wrap"
+                           TextAlignment="Center"
+                           Text=""/>
+            </Border>
         </StackPanel>
         <Canvas x:Name="AlertCanvas" ClipToBounds="False" Visibility="Collapsed">
             <Image Source="/Assets/Images/UpdateWarn.png" Canvas.Left="50" Canvas.Top="32" Width="14" Height="14"></Image>

--- a/DesktopEdge/MainWindow.xaml
+++ b/DesktopEdge/MainWindow.xaml
@@ -375,11 +375,18 @@
         <Rectangle x:Name="ModalBg" MouseDown="Window_MouseDown" Margin="10,10,10,10" Fill="Black" RadiusY="10" RadiusX="10" Opacity="0" Visibility="Collapsed"></Rectangle>
         <!-- MFA Setup Prompt -->
         <local:MFAScreen x:Name="MFASetup" Visibility="Collapsed" Margin="0,0,0,0" OnClose="DoClose"></local:MFAScreen>
-        <local:AddIdentityUrl x:Name="AddIdentityByURL" 
-                              Visibility="Collapsed" 
-                              Margin="0,0,0,0" 
-                              OnClose="CloseJoinByUrl" 
-                              Height="Auto" 
+        <local:AddIdentityUrl x:Name="AddIdentityByURL"
+                              Visibility="Collapsed"
+                              Margin="0,0,0,0"
+                              OnClose="CloseJoinByUrl"
+                              Height="Auto"
+                              OnAddIdentity="OnAddIdentityAction"
+                              OnNeedsSignerChoice="OnNeedsSignerChoiceAction" />
+        <local:AddIdentitySignerChoice x:Name="AddIdentitySignerPicker"
+                              Visibility="Collapsed"
+                              Margin="0,0,0,0"
+                              OnClose="CloseJoinByUrl"
+                              Height="Auto"
                               OnAddIdentity="OnAddIdentityAction" />
         <local:AddIdentityCA x:Name="AddIdentityBy3rdPartyCA"
                               Visibility="Collapsed" 

--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -1884,6 +1884,12 @@ namespace ZitiDesktopEdge {
                 Identity createdId = await serviceClient.AddIdentityAsync(payload);
 
                 if (createdId != null) {
+                    // External-auth enrollment: zet returns an auth URL instead of a full identity.
+                    // Launch the browser; zet will emit a normal identity event once the user signs in.
+                    if (!string.IsNullOrEmpty(createdId.Url)) {
+                        System.Diagnostics.Process.Start(createdId.Url);
+                        return;
+                    }
                     var zid = ZitiIdentity.FromClient(createdId);
                     AddIdentity(zid);
                     LoadIdentities(true);

--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -284,26 +284,27 @@ namespace ZitiDesktopEdge {
         }
 
         private void ShowJoinByUrl() {
-            AddIdentityByURL.Opacity = 0;
-            AddIdentityByURL.Visibility = Visibility.Visible;
-            AddIdentityByURL.Margin = new Thickness(0, 0, 0, 0);
-
-            DoubleAnimation animation = new DoubleAnimation(1, TimeSpan.FromSeconds(.3));
-            AddIdentityByURL.BeginAnimation(Grid.OpacityProperty, animation);
-            AddIdentityByURL.BeginAnimation(Grid.MarginProperty, new ThicknessAnimation(new Thickness(30, 30, 30, 30), TimeSpan.FromSeconds(.3)));
-
+            AnimateDialogIn(AddIdentityByURL);
             ShowModal();
         }
         
+        private void AnimateDialogIn(UserControl dialog) {
+            dialog.Opacity = 0;
+            dialog.Visibility = Visibility.Visible;
+            dialog.Margin = new Thickness(0, 0, 0, 0);
+            dialog.BeginAnimation(Grid.OpacityProperty, new DoubleAnimation(1, TimeSpan.FromSeconds(.3)));
+            dialog.BeginAnimation(Grid.MarginProperty, new ThicknessAnimation(new Thickness(30, 30, 30, 30), TimeSpan.FromSeconds(.3)));
+        }
+
+        private void AnimateDialogOut(UserControl dialog) {
+            DoubleAnimation fade = new DoubleAnimation(0, TimeSpan.FromSeconds(.3));
+            fade.Completed += (s, e) => dialog.Visibility = Visibility.Collapsed;
+            dialog.BeginAnimation(Grid.OpacityProperty, fade);
+            dialog.BeginAnimation(Grid.MarginProperty, new ThicknessAnimation(new Thickness(0, 0, 0, 0), TimeSpan.FromSeconds(.3)));
+        }
+
         private void ShowJoinWith3rdPartyCA() {
-            AddIdentityBy3rdPartyCA.Opacity = 0;
-            AddIdentityBy3rdPartyCA.Visibility = Visibility.Visible;
-            AddIdentityBy3rdPartyCA.Margin = new Thickness(0, 0, 0, 0);
-
-            DoubleAnimation animation = new DoubleAnimation(1, TimeSpan.FromSeconds(.3));
-            AddIdentityBy3rdPartyCA.BeginAnimation(Grid.OpacityProperty, animation);
-            AddIdentityBy3rdPartyCA.BeginAnimation(Grid.MarginProperty, new ThicknessAnimation(new Thickness(30, 30, 30, 30), TimeSpan.FromSeconds(.3)));
-
+            AnimateDialogIn(AddIdentityBy3rdPartyCA);
             ShowModal();
         }
 
@@ -364,13 +365,7 @@ namespace ZitiDesktopEdge {
             ModalBg.Visibility = Visibility.Collapsed;
         }
         private void CloseJoinByUrl(bool isComplete, UserControl sender) {
-            DoubleAnimation animation = new DoubleAnimation(0, TimeSpan.FromSeconds(.3));
-            ThicknessAnimation animateThick = new ThicknessAnimation(new Thickness(0, 0, 0, 0), TimeSpan.FromSeconds(.3));
-            animation.Completed += (s, e) => {
-                sender.Visibility = Visibility.Collapsed;
-            };
-            sender.BeginAnimation(Grid.OpacityProperty, animation);
-            sender.BeginAnimation(Grid.MarginProperty, animateThick);
+            AnimateDialogOut(sender);
             HideModal();
         }
 
@@ -2258,6 +2253,13 @@ namespace ZitiDesktopEdge {
             if (!UIUtils.IsLeftClick(e)) return;
             if (!UIUtils.MouseUpForMouseDown(e)) return;
             ShowJoinWith3rdPartyCA();
+        }
+
+        void OnNeedsSignerChoiceAction(AddIdentityViewModel vm, UserControl toClose) {
+            // Swap dialogs without touching the modal overlay so the main window stays dimmed.
+            AnimateDialogOut(toClose);
+            AddIdentitySignerPicker.Prepare(vm);
+            AnimateDialogIn(AddIdentitySignerPicker);
         }
 
         async void OnAddIdentityAction(EnrollIdentifierPayload payload, UserControl toClose) {

--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -1312,6 +1312,7 @@ namespace ZitiDesktopEdge {
                     item.StopTimers();
                 }
                 IdList.Children.Clear();
+                identities.Clear();
                 if (e != null) {
                     logger.Debug(e.ToString());
                 }

--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -1623,7 +1623,7 @@ namespace ZitiDesktopEdge {
                 } else {
                     Application.Current.Properties["PcapInterface"] = status?.PcapInterface;
                 }
-                identities.Clear();
+                
                 foreach (var id in status.Identities) {
                     updateViewWithIdentity(id);
                 }

--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -566,6 +566,161 @@ namespace ZitiDesktopEdge {
                 if (IdentityMenu.Visibility == Visibility.Visible) IdentityMenu.Visibility = Visibility.Collapsed;
                 else if (MainMenu.Visibility == Visibility.Visible) MainMenu.Visibility = Visibility.Collapsed;
             }
+
+            // Ctrl+Shift+T : open the dev-only tunneler instance picker
+            if (e.Key == Key.T
+                    && (Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control
+                    && (Keyboard.Modifiers & ModifierKeys.Shift) == ModifierKeys.Shift) {
+                OpenTunnelInstancePicker();
+                e.Handled = true;
+            }
+        }
+
+        private void OpenTunnelInstancePicker() {
+            // If there's only one ziti-edge-tunnel instance running, there's
+            // nothing useful to switch to — suppress the picker entirely.
+            _ = OpenTunnelInstancePickerAsync();
+        }
+
+        private async Task OpenTunnelInstancePickerAsync() {
+            try {
+                var instances = await TunnelInstanceDiscovery.EnumerateAsync();
+                if (instances.Count <= 1) {
+                    logger.Debug("Ctrl+Shift+T ignored — only {0} tunneler instance running", instances.Count);
+                    return;
+                }
+            } catch (Exception ex) {
+                logger.Debug(ex, "enumeration failed when opening picker; showing it anyway");
+            }
+
+            bool picked = false;
+            string chosen = null;
+            this.Dispatcher.Invoke(() => {
+                string tmp;
+                picked = PromptForInstance(out tmp);
+                chosen = tmp;
+            });
+            if (picked) {
+                await SwitchToInstanceAsync(chosen);
+            }
+        }
+
+        /// <summary>
+        /// Shows the picker modally. Returns true if the user chose an instance
+        /// (populating <paramref name="discriminator"/> with null for default
+        /// or the picked name); false if the user dismissed the dialog.
+        /// </summary>
+        private bool PromptForInstance(out string discriminator) {
+            discriminator = null;
+            try {
+                var picker = new TunnelInstancePickerWindow(serviceClient?.Discriminator);
+                if (this.IsLoaded) picker.Owner = this;
+                bool? dialog = picker.ShowDialog();
+                if (dialog == true && picker.InstanceSelected) {
+                    discriminator = picker.SelectedDiscriminator;
+                    return true;
+                }
+            } catch (Exception ex) {
+                logger.Error(ex, "failed to open tunnel instance picker");
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Startup: pick whichever ziti-edge-tunnel instance to connect to.
+        /// Rules:
+        ///   0 running          — fall back to the default-pipe reconnect loop.
+        ///   1 running          — connect to it, default or not.
+        ///   2+ with default    — connect to default (preserves prior behaviour).
+        ///   2+ without default — pop the picker; user cancel → reconnect loop.
+        /// </summary>
+        private async Task ChooseAndConnectOnStartupAsync() {
+            IReadOnlyList<TunnelInstanceDiscovery.TunnelInstance> instances = null;
+            try {
+                instances = await TunnelInstanceDiscovery.EnumerateAsync();
+            } catch (Exception ex) {
+                logger.Debug(ex, "instance enumeration failed on startup");
+            }
+
+            if (instances == null || instances.Count == 0) {
+                logger.Info("no running ziti-edge-tunnel instances found on startup — entering reconnect loop on default");
+                ShowServiceNotStarted();
+                serviceClient.Reconnect();
+                return;
+            }
+
+            if (instances.Count == 1) {
+                var only = instances[0];
+                logger.Info("exactly one tunnel instance running on startup ('{0}') — auto-connecting", only.DisplayLabel);
+                await SwitchToInstanceAsync(only.Discriminator);
+                return;
+            }
+
+            var def = instances.FirstOrDefault(i => string.IsNullOrEmpty(i.Discriminator));
+            if (def != null) {
+                logger.Info("{0} instances running on startup, default is one of them — connecting to default", instances.Count);
+                await SwitchToInstanceAsync(null);
+                return;
+            }
+
+            logger.Info("{0} tunnel instances running on startup, none is the default — opening picker", instances.Count);
+            string chosen;
+            if (PromptForInstance(out chosen)) {
+                await SwitchToInstanceAsync(chosen);
+            } else {
+                ShowServiceNotStarted();
+                serviceClient.Reconnect();
+            }
+        }
+
+
+        private async Task SwitchToInstanceAsync(string discriminator) {
+            logger.Info("switching tunneler instance to '{0}'", discriminator ?? "default");
+            this.Dispatcher.Invoke(() => {
+                ResetTunnelerScopedState();
+                ShowLoad("Switching tunneler", "Connecting to '" + (discriminator ?? "default") + "'…");
+            });
+            try {
+                await serviceClient.SwitchInstanceAsync(discriminator);
+                this.Dispatcher.Invoke(() => HideLoad());
+            } catch (Exception ex) {
+                logger.Error(ex, "failed to switch tunneler instance to '{0}'", discriminator ?? "default");
+                this.Dispatcher.Invoke(() => {
+                    HideLoad();
+                    ShowError("Switch failed", "Could not connect to '" + (discriminator ?? "default") + "': " + ex.Message);
+                    ShowServiceNotStarted();
+                });
+            }
+        }
+
+        /// <summary>
+        /// True when the UI is currently viewing the default ziti-edge-tunnel
+        /// instance. The big start/stop/force-terminate button always targets
+        /// the default Windows service regardless; this is purely for
+        /// cosmetic signals (e.g. the alternate-tunnel footer).
+        /// </summary>
+        private bool IsViewingDefaultInstance {
+            get { return string.IsNullOrEmpty(serviceClient?.Discriminator); }
+        }
+
+        /// <summary>
+        /// Show/hide the "you are viewing an alternate tunneler" footer based
+        /// on the current <see cref="DataClient.Discriminator"/>. Safe to call
+        /// from any thread — bounces to the Dispatcher.
+        /// </summary>
+        private void UpdateAlternateTunnelFooter() {
+            this.Dispatcher.Invoke(() => {
+                if (AlternateTunnelFooter == null) return;
+                string disc = serviceClient?.Discriminator;
+                if (string.IsNullOrEmpty(disc)) {
+                    AlternateTunnelFooter.Visibility = Visibility.Collapsed;
+                    AlternateTunnelFooterText.Text = "";
+                } else {
+                    AlternateTunnelFooter.Visibility = Visibility.Visible;
+                    AlternateTunnelFooterText.Text =
+                        "viewing alternate tunneler: ziti-edge-tunnel.sock." + disc;
+                }
+            });
         }
 
         private void MFASetup_OnLoad(bool isComplete, string title, string message) {
@@ -760,14 +915,7 @@ namespace ZitiDesktopEdge {
             MainMenu.OnShowBlurb += MainMenu_OnShowBlurb;
             IdentityMenu.OnError += IdentityMenu_OnError;
 
-            try {
-                await serviceClient.ConnectAsync();
-                await serviceClient.WaitForConnectionAsync();
-            } catch /*ignored for now (Exception ex) */
-              {
-                ShowServiceNotStarted();
-                serviceClient.Reconnect();
-            }
+            await ChooseAndConnectOnStartupAsync();
 
             try {
                 await monitorClient.ConnectAsync();
@@ -1018,8 +1166,22 @@ namespace ZitiDesktopEdge {
                             logger.Info("Service is stopping...");
 
                             this.Dispatcher.Invoke(async () => {
-                                SetCantDisplay("The Service is Stopping", "Please wait while the service stops", Visibility.Visible);
-                                await WaitForServiceToStop(DateTime.Now + TimeSpan.FromSeconds(30));
+                                ShowLoad("Service is Stopping", "Please wait while the service stops");
+                                try {
+                                    await WaitForServiceToStop(DateTime.Now + TimeSpan.FromSeconds(30));
+                                } finally {
+                                    // Wipe identity UI before removing the modal so the
+                                    // user doesn't briefly see stale identities after the
+                                    // modal disappears (ClientDisconnected would clear
+                                    // them a moment later, but that's visibly laggy).
+                                    // If WaitForServiceToStop hit its timeout it has
+                                    // already replaced the modal with the "Service
+                                    // Appears Stuck" error (which owns the Force Quit
+                                    // button); HideLoad in that case is a harmless no-op
+                                    // on the already-hidden modal.
+                                    ResetTunnelerScopedState();
+                                    HideLoad();
+                                }
                             });
                             break;
                         case ServiceControllerStatus.StartPending:
@@ -1211,6 +1373,8 @@ namespace ZitiDesktopEdge {
         async private void ForceQuitButtonClick(object sender, RoutedEventArgs e) {
             if (!UIUtils.IsLeftClick(e)) return;
             if (!UIUtils.MouseUpForMouseDown(e)) return;
+            // Targets the default Windows-service-managed tunneler regardless
+            // of which instance is currently being viewed.
             MonitorServiceStatusEvent status = await monitorClient.ForceTerminateAsync();
             if (status.IsStopped()) {
                 //good
@@ -1225,6 +1389,7 @@ namespace ZitiDesktopEdge {
         async private void StartZitiService(object sender, RoutedEventArgs e) {
             if (!UIUtils.IsLeftClick(e)) return;
             if (!UIUtils.MouseUpForMouseDown(e)) return;
+            // Always targets the default Windows service.
             try {
                 ShowLoad("Starting", "Starting the data service");
                 logger.Info("StartZitiService");
@@ -1297,30 +1462,86 @@ namespace ZitiDesktopEdge {
                 UpdateServiceView();
                 SetNotifyIcon("white");
                 LoadIdentities(true);
+                UpdateAlternateTunnelFooter();
             });
         }
 
         private void ServiceClient_OnClientDisconnected(object sender, object e) {
             this.Dispatcher.Invoke(() => {
-                AddIdAreaButton.IsEnabled = false;
-                IdentityMenu.Visibility = Visibility.Collapsed;
-                MFASetup.Visibility = Visibility.Collapsed;
-                HideModal();
-                MainMenu.Disconnected();
-                for (int i = 0; i < IdList.Children.Count; i++) {
-                    IdentityItem item = (IdentityItem)IdList.Children[i];
-                    item.StopTimers();
-                }
-                IdList.Children.Clear();
-                identities.Clear();
+                ResetTunnelerScopedState();
                 if (e != null) {
                     logger.Debug(e.ToString());
                 }
-                //SetCantDisplay("Start the Ziti Tunnel Service to continue");
                 SetNotifyIcon("red");
-                _notificationThrottle.Clear();
                 ShowServiceNotStarted();
+                // The underlying DataClient has already kicked off its own
+                // reconnect loop against whatever pipe we were viewing. If the
+                // user wants to view a different instance they can hit
+                // Ctrl+Shift+T.
             });
+        }
+
+        /// <summary>
+        /// Wipes all UI and in-memory state scoped to the currently-connected
+        /// ziti-edge-tunnel instance. Safe to call when nothing is connected.
+        /// Called by the disconnect handler and (later) by the instance switcher
+        /// before reconnecting to a different tunneler.
+        ///
+        /// Must be invoked on the UI thread.
+        /// </summary>
+        private void ResetTunnelerScopedState() {
+            AddIdAreaButton.IsEnabled = false;
+            IdentityMenu.Visibility = Visibility.Collapsed;
+            MFASetup.Visibility = Visibility.Collapsed;
+            HideModal();
+            MainMenu.Disconnected();
+
+            for (int i = 0; i < IdList.Children.Count; i++) {
+                IdentityItem item = (IdentityItem)IdList.Children[i];
+                item.StopTimers();
+            }
+            IdList.Children.Clear();
+            identities.Clear();
+
+            StopTunnelUptimeTimer();
+            _startDate = default(DateTime);
+            ConnectedTime.Content = "00:00:00";
+
+            DownloadSpeed.Content = "0.0";
+            UploadSpeed.Content = "0.0";
+
+            _notificationThrottle?.Clear();
+            NextNotificationTime = DateTime.Now;
+
+            var props = Application.Current.Properties;
+            props.Remove("CurrentTunnelStatus");
+            props.Remove("ip");
+            props.Remove("subnet");
+            props.Remove("mtu");
+            props.Remove("dns");
+            props.Remove("dnsenabled");
+            props.Remove("ApiPageSize");
+            props.Remove("L2Enabled");
+            props.Remove("PcapInterface");
+
+            // Hide the alternate-tunnel footer while we're not connected; it
+            // will come back when ClientConnected fires (discriminator
+            // persists across a reconnect on the same pipe).
+            if (AlternateTunnelFooter != null) {
+                AlternateTunnelFooter.Visibility = Visibility.Collapsed;
+            }
+        }
+
+        private void StopTunnelUptimeTimer() {
+            if (_tunnelUptimeTimer == null) return;
+            try {
+                _tunnelUptimeTimer.Stop();
+                _tunnelUptimeTimer.Tick -= OnTimedEvent;
+                _tunnelUptimeTimer.Dispose();
+            } catch (Exception ex) {
+                logger.Debug(ex, "error while stopping tunnel uptime timer");
+            }
+            _tunnelUptimeTimer = null;
         }
 
         /// <summary>
@@ -2012,6 +2233,7 @@ namespace ZitiDesktopEdge {
         }
 
         private void InitializeTimer(int millisAgoStarted) {
+            StopTunnelUptimeTimer();
             _startDate = DateTime.Now.Subtract(new TimeSpan(0, 0, 0, 0, millisAgoStarted));
             _tunnelUptimeTimer = new System.Windows.Forms.Timer();
             _tunnelUptimeTimer.Interval = 100;
@@ -2023,6 +2245,7 @@ namespace ZitiDesktopEdge {
         async private void Disconnect(object sender, RoutedEventArgs e) {
             if (!UIUtils.IsLeftClick(e)) return;
             if (!UIUtils.MouseUpForMouseDown(e)) return;
+            // Always targets the default Windows service.
             try {
                 ShowLoad("Disabling Service", "Please wait for the service to stop.");
                 var r = await monitorClient.StopServiceAsync();

--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -627,47 +627,17 @@ namespace ZitiDesktopEdge {
         }
 
         /// <summary>
-        /// Startup: pick whichever ziti-edge-tunnel instance to connect to.
-        /// Rules:
-        ///   0 running          — fall back to the default-pipe reconnect loop.
-        ///   1 running          — connect to it, default or not.
-        ///   2+ with default    — connect to default (preserves prior behaviour).
-        ///   2+ without default — pop the picker; user cancel → reconnect loop.
+        /// Startup: connect to the default ziti-edge-tunnel instance. If it
+        /// isn't running, show the not-started banner and let the reconnect
+        /// loop poll for it. Non-default instances are reached exclusively via
+        /// the Ctrl+Shift+T picker — startup never auto-routes to them.
         /// </summary>
         private async Task ChooseAndConnectOnStartupAsync() {
-            IReadOnlyList<TunnelInstanceDiscovery.TunnelInstance> instances = null;
             try {
-                instances = await TunnelInstanceDiscovery.EnumerateAsync();
-            } catch (Exception ex) {
-                logger.Debug(ex, "instance enumeration failed on startup");
-            }
-
-            if (instances == null || instances.Count == 0) {
-                logger.Info("no running ziti-edge-tunnel instances found on startup — entering reconnect loop on default");
-                ShowServiceNotStarted();
-                serviceClient.Reconnect();
-                return;
-            }
-
-            if (instances.Count == 1) {
-                var only = instances[0];
-                logger.Info("exactly one tunnel instance running on startup ('{0}') — auto-connecting", only.DisplayLabel);
-                await SwitchToInstanceAsync(only.Discriminator);
-                return;
-            }
-
-            var def = instances.FirstOrDefault(i => string.IsNullOrEmpty(i.Discriminator));
-            if (def != null) {
-                logger.Info("{0} instances running on startup, default is one of them — connecting to default", instances.Count);
-                await SwitchToInstanceAsync(null);
-                return;
-            }
-
-            logger.Info("{0} tunnel instances running on startup, none is the default — opening picker", instances.Count);
-            string chosen;
-            if (PromptForInstance(out chosen)) {
-                await SwitchToInstanceAsync(chosen);
-            } else {
+                await serviceClient.ConnectAsync();
+                await serviceClient.WaitForConnectionAsync();
+            } catch /*ignored for now (Exception ex) */
+              {
                 ShowServiceNotStarted();
                 serviceClient.Reconnect();
             }

--- a/DesktopEdge/TunnelInstancePickerWindow.cs
+++ b/DesktopEdge/TunnelInstancePickerWindow.cs
@@ -1,0 +1,219 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
+
+using ZitiDesktopEdge.ServiceClient;
+
+namespace ZitiDesktopEdge {
+    /// <summary>
+    /// Dev-grade picker: enumerates all running ziti-edge-tunnel instances and
+    /// lets the user click one to switch ZDEW's view to it. Pure-code WPF
+    /// window — intentionally minimal. Replace with a polished MainMenu entry
+    /// once the plumbing is proven.
+    ///
+    /// Opened with Ctrl+Shift+T from MainWindow.
+    /// </summary>
+    public class TunnelInstancePickerWindow : Window {
+        public string SelectedDiscriminator { get; private set; }
+        public bool InstanceSelected { get; private set; }
+
+        private readonly StackPanel stack;
+        private readonly TextBlock statusLabel;
+        private readonly string activeDiscriminator;
+
+        public TunnelInstancePickerWindow(string activeDiscriminator) {
+            this.activeDiscriminator = activeDiscriminator;
+            Title = "Switch tunneler instance (dev)";
+            Width = 420;
+            Height = 360;
+            WindowStartupLocation = WindowStartupLocation.CenterOwner;
+            ResizeMode = ResizeMode.NoResize;
+            Background = new SolidColorBrush(Color.FromRgb(0x1e, 0x1e, 0x28));
+
+            var root = new DockPanel { Margin = new Thickness(12) };
+
+            statusLabel = new TextBlock {
+                Text = "enumerating pipes…",
+                Foreground = Brushes.Gainsboro,
+                Margin = new Thickness(2, 2, 2, 8),
+                FontFamily = new FontFamily("Segoe UI")
+            };
+            DockPanel.SetDock(statusLabel, Dock.Top);
+            root.Children.Add(statusLabel);
+
+            var refreshBtn = new Button {
+                Content = "Refresh",
+                Margin = new Thickness(2, 0, 2, 8),
+                Padding = new Thickness(8, 4, 8, 4),
+                HorizontalAlignment = HorizontalAlignment.Right
+            };
+            refreshBtn.Click += async (_, __) => await PopulateAsync();
+            DockPanel.SetDock(refreshBtn, Dock.Top);
+            root.Children.Add(refreshBtn);
+
+            var scroll = new ScrollViewer {
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                Background = Brushes.Transparent
+            };
+            stack = new StackPanel();
+            scroll.Content = stack;
+            root.Children.Add(scroll);
+
+            Content = root;
+            Loaded += async (_, __) => await PopulateAsync();
+        }
+
+        private async Task PopulateAsync() {
+            stack.Children.Clear();
+            statusLabel.Text = "enumerating pipes…";
+
+            IReadOnlyList<TunnelInstanceDiscovery.TunnelInstance> discovered;
+            try {
+                discovered = await TunnelInstanceDiscovery.EnumerateAsync();
+            } catch (Exception ex) {
+                statusLabel.Text = "enumeration failed: " + ex.Message;
+                return;
+            }
+
+            // Assemble the display list: default is always first, synthetic if
+            // it's not actually running. Everything else follows in the order
+            // discovery returned them.
+            var ordered = new List<TunnelInstanceDiscovery.TunnelInstance>();
+            var def = discovered.FirstOrDefault(i => string.IsNullOrEmpty(i.Discriminator));
+            ordered.Add(def ?? TunnelInstanceDiscovery.OfflineDefault());
+            foreach (var inst in discovered) {
+                if (!string.IsNullOrEmpty(inst.Discriminator)) ordered.Add(inst);
+            }
+
+            int liveCount = ordered.Count(i => i.IsOnline);
+            statusLabel.Text = liveCount == 0
+                ? "no tunnelers running. start one or click default to retry."
+                : (liveCount == 1 ? "1 instance running." : liveCount + " instances running.")
+                    + " click to switch.";
+
+            foreach (var inst in ordered) {
+                stack.Children.Add(BuildInstanceRow(inst));
+            }
+        }
+
+        private static readonly Color RowBg = Color.FromRgb(0x2a, 0x2a, 0x38);
+        private static readonly Color RowBgHover = Color.FromRgb(0x36, 0x36, 0x48);
+        private static readonly Color RowBorder = Color.FromRgb(0x3a, 0x3a, 0x48);
+        private static readonly Color ActiveBg = Color.FromRgb(0x23, 0x35, 0x28);
+        private static readonly Color ActiveBorder = Color.FromRgb(0x4a, 0xc8, 0x4a);
+
+        private FrameworkElement BuildInstanceRow(TunnelInstanceDiscovery.TunnelInstance inst) {
+            bool isActive = string.Equals(inst.Discriminator ?? "", activeDiscriminator ?? "", StringComparison.Ordinal)
+                            && inst.IsOnline;
+
+            string suffix = isActive ? "   (active)" : (!inst.IsOnline ? "   (not running)" : "");
+            var panel = new StackPanel { Orientation = Orientation.Vertical };
+            panel.Children.Add(new TextBlock {
+                Text = inst.DisplayLabel + suffix,
+                FontWeight = FontWeights.Bold,
+                Foreground = inst.IsOnline ? Brushes.White : new SolidColorBrush(Color.FromRgb(0xa0, 0xa0, 0xa8)),
+                FontFamily = new FontFamily("Segoe UI")
+            });
+
+            string subtitle;
+            if (!inst.IsOnline) {
+                subtitle = "pipe: " + inst.PipeName + "    — click to attempt connect";
+            } else {
+                subtitle = "pipe: " + inst.PipeName;
+                if (!string.IsNullOrEmpty(inst.TunName)) subtitle += "    tun: " + inst.TunName;
+                if (!string.IsNullOrEmpty(inst.Ip)) subtitle += "    ip: " + inst.Ip;
+                if (!string.IsNullOrEmpty(inst.Dns)) subtitle += "    dns: " + inst.Dns;
+            }
+            panel.Children.Add(new TextBlock {
+                Text = subtitle,
+                Foreground = inst.IsOnline ? Brushes.LightGray : new SolidColorBrush(Color.FromRgb(0x80, 0x80, 0x88)),
+                FontSize = 11,
+                FontFamily = new FontFamily("Consolas"),
+                TextWrapping = TextWrapping.Wrap
+            });
+
+            if (isActive) {
+                // Non-interactive — a Border avoids any WPF default hover styling.
+                return new Border {
+                    Child = panel,
+                    Margin = new Thickness(0, 0, 0, 6),
+                    Padding = new Thickness(12, 8, 12, 8),
+                    Background = new SolidColorBrush(ActiveBg),
+                    BorderBrush = new SolidColorBrush(ActiveBorder),
+                    BorderThickness = new Thickness(2),
+                    CornerRadius = new CornerRadius(2),
+                };
+            }
+
+            var btn = new Button {
+                Content = panel,
+                Margin = new Thickness(0, 0, 0, 6),
+                Padding = new Thickness(12, 8, 12, 8),
+                HorizontalContentAlignment = HorizontalAlignment.Left,
+                Foreground = Brushes.White,
+                Cursor = System.Windows.Input.Cursors.Hand,
+                Template = BuildRowTemplate()
+            };
+            btn.Click += (_, __) => {
+                SelectedDiscriminator = inst.Discriminator;
+                InstanceSelected = true;
+                DialogResult = true;
+                Close();
+            };
+            return btn;
+        }
+
+        /// <summary>
+        /// Minimal ControlTemplate for row buttons. Replaces the WPF default
+        /// (which flips to a light-blue on hover, unusable against the dark
+        /// theme) with a two-state dark-on-darker hover.
+        /// </summary>
+        private static ControlTemplate BuildRowTemplate() {
+            var tpl = new ControlTemplate(typeof(Button));
+            var border = new FrameworkElementFactory(typeof(Border));
+            border.Name = "RowBorder";
+            border.SetValue(Border.BackgroundProperty, new SolidColorBrush(RowBg));
+            border.SetValue(Border.BorderBrushProperty, new SolidColorBrush(RowBorder));
+            border.SetValue(Border.BorderThicknessProperty, new Thickness(1));
+            border.SetValue(Border.CornerRadiusProperty, new CornerRadius(2));
+            border.SetValue(Border.PaddingProperty, new TemplateBindingExtension(Control.PaddingProperty));
+
+            var presenter = new FrameworkElementFactory(typeof(ContentPresenter));
+            presenter.SetValue(ContentPresenter.HorizontalAlignmentProperty, HorizontalAlignment.Left);
+            presenter.SetValue(ContentPresenter.VerticalAlignmentProperty, VerticalAlignment.Center);
+            border.AppendChild(presenter);
+            tpl.VisualTree = border;
+
+            var hoverTrigger = new Trigger { Property = UIElement.IsMouseOverProperty, Value = true };
+            hoverTrigger.Setters.Add(new Setter(Border.BackgroundProperty, new SolidColorBrush(RowBgHover), "RowBorder"));
+            tpl.Triggers.Add(hoverTrigger);
+
+            var pressedTrigger = new Trigger { Property = ButtonBase.IsPressedProperty, Value = true };
+            pressedTrigger.Setters.Add(new Setter(Border.BackgroundProperty, new SolidColorBrush(ActiveBg), "RowBorder"));
+            tpl.Triggers.Add(pressedTrigger);
+
+            return tpl;
+        }
+    }
+}

--- a/DesktopEdge/ViewModels/AddIdentityViewModel.cs
+++ b/DesktopEdge/ViewModels/AddIdentityViewModel.cs
@@ -14,12 +14,9 @@
 	limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Net.Http;
-using System.Threading.Tasks;
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -34,16 +31,8 @@ namespace ZitiDesktopEdge {
     }
 
     public class AddIdentityViewModel : INotifyPropertyChanged {
-        // Fixed by the Ziti edge API contract. The deployment-specific path prefix
-        // (e.g. "/edge/client/v1") is read from the controller's root response instead.
-        private const string EdgeClientApiFamily = "edge-client";
-        private const string EdgeClientApiVersion = "v1";
-        private const string ExternalJwtSignersSuffix = "/external-jwt-signers";
-        private static readonly TimeSpan DiscoveryTimeout = TimeSpan.FromSeconds(5);
-
         private ExternalJwtSigner _selectedSigner;
         private string _enrollMode;
-        private bool _isDiscovering;
 
         public ObservableCollection<ExternalJwtSigner> Signers { get; } = new ObservableCollection<ExternalJwtSigner>();
 
@@ -63,56 +52,20 @@ namespace ZitiDesktopEdge {
             }
         }
 
-        public bool IsDiscovering {
-            get { return _isDiscovering; }
-            private set {
-                _isDiscovering = value;
-                OnPropertyChanged(nameof(IsDiscovering));
-            }
-        }
-
         /// <summary>
-        /// Replaces <see cref="Signers"/> with the controller's external JWT signers.
-        /// The caller provides the already-fetched preflight body so we don't re-GET the root.
-        /// HTTP and parsing errors propagate.
+        /// Parses the controller's external-jwt-signers response and replaces <see cref="Signers"/>.
+        /// Parsing errors propagate so the caller can surface a specific error.
         /// </summary>
-        public async Task DiscoverSignersAsync(string controllerUrl, string controllerRootBody) {
+        public void LoadSigners(string signersResponseBody) {
             Signers.Clear();
             SelectedSigner = null;
-            IsDiscovering = true;
-            try {
-                Uri baseUri = new Uri(controllerUrl);
-                string edgeClientPath = ExtractEdgeClientApiPath(controllerRootBody, baseUri);
-                Uri signersUri = new Uri(baseUri, edgeClientPath + ExternalJwtSignersSuffix);
 
-                using (HttpClient client = new HttpClient()) {
-                    client.Timeout = DiscoveryTimeout;
-                    string signersBody = await client.GetStringAsync(signersUri);
-                    ExternalJwtSignerListResponse parsed = JsonConvert.DeserializeObject<ExternalJwtSignerListResponse>(signersBody, DeserializationSettings);
-                    if (parsed?.Data != null) {
-                        foreach (ExternalJwtSigner signer in parsed.Data) {
-                            Signers.Add(signer);
-                        }
-                    }
+            ExternalJwtSignerListResponse parsed = JsonConvert.DeserializeObject<ExternalJwtSignerListResponse>(signersResponseBody, DeserializationSettings);
+            if (parsed?.Data != null) {
+                foreach (ExternalJwtSigner signer in parsed.Data) {
+                    Signers.Add(signer);
                 }
-            } finally {
-                IsDiscovering = false;
             }
-        }
-
-        private static string ExtractEdgeClientApiPath(string rootBody, Uri baseUri) {
-            ControllerRootResponse root = JsonConvert.DeserializeObject<ControllerRootResponse>(rootBody, DeserializationSettings);
-
-            Dictionary<string, ApiVersionInfo> edgeClient = null;
-            root?.Data?.ApiVersions?.TryGetValue(EdgeClientApiFamily, out edgeClient);
-            ApiVersionInfo v1 = null;
-            edgeClient?.TryGetValue(EdgeClientApiVersion, out v1);
-
-            if (string.IsNullOrEmpty(v1?.Path)) {
-                throw new InvalidOperationException(
-                    $"Controller at {baseUri} did not advertise an '{EdgeClientApiFamily}.{EdgeClientApiVersion}.path' in its root response.");
-            }
-            return v1.Path;
         }
 
         public event PropertyChangedEventHandler PropertyChanged;
@@ -125,18 +78,6 @@ namespace ZitiDesktopEdge {
         private static readonly JsonSerializerSettings DeserializationSettings = new JsonSerializerSettings {
             ContractResolver = new CamelCasePropertyNamesContractResolver()
         };
-
-        private class ControllerRootResponse {
-            public ControllerRootData Data { get; set; }
-        }
-
-        private class ControllerRootData {
-            public Dictionary<string, Dictionary<string, ApiVersionInfo>> ApiVersions { get; set; }
-        }
-
-        private class ApiVersionInfo {
-            public string Path { get; set; }
-        }
 
         private class ExternalJwtSignerListResponse {
             public List<ExternalJwtSigner> Data { get; set; }

--- a/DesktopEdge/ViewModels/AddIdentityViewModel.cs
+++ b/DesktopEdge/ViewModels/AddIdentityViewModel.cs
@@ -17,6 +17,8 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Linq;
+using System.Windows;
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -33,8 +35,23 @@ namespace ZitiDesktopEdge {
     public class AddIdentityViewModel : INotifyPropertyChanged {
         private ExternalJwtSigner _selectedSigner;
         private string _enrollMode;
+        private bool _showSignerPicker;
+
+        /// <summary>Initial placeholder shown in the controller URL field, also used to detect whether the user has entered a real URL.</summary>
+        public string UrlPlaceholder { get; } = "https://controller.url";
 
         public ObservableCollection<ExternalJwtSigner> Signers { get; } = new ObservableCollection<ExternalJwtSigner>();
+
+        public bool ShowSignerPicker {
+            get { return _showSignerPicker; }
+            private set {
+                _showSignerPicker = value;
+                OnPropertyChanged(nameof(ShowSignerPicker));
+                OnPropertyChanged(nameof(SignerPickerVisibility));
+            }
+        }
+
+        public Visibility SignerPickerVisibility => _showSignerPicker ? Visibility.Visible : Visibility.Collapsed;
 
         public ExternalJwtSigner SelectedSigner {
             get { return _selectedSigner; }
@@ -66,6 +83,24 @@ namespace ZitiDesktopEdge {
                     Signers.Add(signer);
                 }
             }
+
+            // Picker rules:
+            //   0 capable signers — no picker, fall through to the current add-by-URL flow.
+            //   1 capable signer  — auto-select it; dropdown stays hidden (no choice to make).
+            //   2+ capable        — show the dropdown, force the user to pick one.
+            List<ExternalJwtSigner> capable = Signers.Where(s => s.SupportsAnyEnrollMode).ToList();
+            if (capable.Count == 1) {
+                SelectedSigner = capable[0];
+            }
+            ShowSignerPicker = capable.Count > 1;
+        }
+
+        /// <summary>Clears any previously-loaded signer state — call when the controller URL changes.</summary>
+        public void Reset() {
+            Signers.Clear();
+            SelectedSigner = null;
+            EnrollMode = null;
+            ShowSignerPicker = false;
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/DesktopEdge/ViewModels/AddIdentityViewModel.cs
+++ b/DesktopEdge/ViewModels/AddIdentityViewModel.cs
@@ -23,13 +23,13 @@ using System.Windows;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
+using ZitiDesktopEdge.DataStructures;
+
 namespace ZitiDesktopEdge {
-    /// <summary>Subset of the controller's external-jwt-signer response used by the add-identity UI.</summary>
     public class ExternalJwtSigner {
         public string Name { get; set; }
         public bool EnrollToCertEnabled { get; set; }
         public bool EnrollToTokenEnabled { get; set; }
-        public bool SupportsAnyEnrollMode => EnrollToCertEnabled || EnrollToTokenEnabled;
     }
 
     public class AddIdentityViewModel : INotifyPropertyChanged {
@@ -37,8 +37,9 @@ namespace ZitiDesktopEdge {
         private string _enrollMode;
         private bool _showSignerPicker;
 
-        /// <summary>Initial placeholder shown in the controller URL field, also used to detect whether the user has entered a real URL.</summary>
         public string UrlPlaceholder { get; } = "https://controller.url";
+        public string ControllerBaseUrl { get; set; }
+        public string IdentityFilename { get; set; }
 
         public ObservableCollection<ExternalJwtSigner> Signers { get; } = new ObservableCollection<ExternalJwtSigner>();
 
@@ -57,7 +58,9 @@ namespace ZitiDesktopEdge {
             get { return _selectedSigner; }
             set {
                 _selectedSigner = value;
+                EnrollMode = (value != null && value.EnrollToCertEnabled) ? "user-session" : null;
                 OnPropertyChanged(nameof(SelectedSigner));
+                OnPropertyChanged(nameof(EnrollModeRadiosVisibility));
             }
         }
 
@@ -66,13 +69,29 @@ namespace ZitiDesktopEdge {
             set {
                 _enrollMode = value;
                 OnPropertyChanged(nameof(EnrollMode));
+                OnPropertyChanged(nameof(IsUserSessionSelected));
+                OnPropertyChanged(nameof(IsDeviceCertificateSelected));
             }
         }
 
-        /// <summary>
-        /// Parses the controller's external-jwt-signers response and replaces <see cref="Signers"/>.
-        /// Parsing errors propagate so the caller can surface a specific error.
-        /// </summary>
+        public bool IsUserSessionSelected {
+            get { return _enrollMode == "user-session"; }
+            set { if (value) EnrollMode = "user-session"; }
+        }
+
+        public bool IsDeviceCertificateSelected {
+            get { return _enrollMode == "device-certificate"; }
+            set { if (value) EnrollMode = "device-certificate"; }
+        }
+
+        public Visibility EnrollModeRadiosVisibility {
+            get {
+                if (_selectedSigner == null) return Visibility.Collapsed;
+                if (!_selectedSigner.EnrollToCertEnabled) return Visibility.Collapsed;
+                return Visibility.Visible;
+            }
+        }
+
         public void LoadSigners(string signersResponseBody) {
             Signers.Clear();
             SelectedSigner = null;
@@ -84,23 +103,49 @@ namespace ZitiDesktopEdge {
                 }
             }
 
-            // Picker rules:
-            //   0 capable signers — no picker, fall through to the current add-by-URL flow.
-            //   1 capable signer  — auto-select it; dropdown stays hidden (no choice to make).
-            //   2+ capable        — show the dropdown, force the user to pick one.
-            List<ExternalJwtSigner> capable = Signers.Where(s => s.SupportsAnyEnrollMode).ToList();
-            if (capable.Count == 1) {
-                SelectedSigner = capable[0];
-            }
+            List<ExternalJwtSigner> capable = Signers.Where(s => s.EnrollToCertEnabled || s.EnrollToTokenEnabled).ToList();
+            if (capable.Count == 1) SelectedSigner = capable[0];
             ShowSignerPicker = capable.Count > 1;
         }
 
-        /// <summary>Clears any previously-loaded signer state — call when the controller URL changes.</summary>
         public void Reset() {
             Signers.Clear();
             SelectedSigner = null;
             EnrollMode = null;
             ShowSignerPicker = false;
+            ControllerBaseUrl = null;
+            IdentityFilename = null;
+        }
+
+        public bool CanJoin {
+            get {
+                if (ShowSignerPicker && SelectedSigner == null) return false;
+                if (EnrollModeRadiosVisibility == Visibility.Visible && EnrollMode == null) return false;
+                return true;
+            }
+        }
+
+        public EnrollIdentifierPayload BuildEnrollPayload() {
+            return new EnrollIdentifierPayload {
+                ControllerURL = ControllerBaseUrl,
+                IdentityFilename = IdentityFilename,
+                EnrollMode = ResolveWireEnrollMode(),
+                Provider = ResolveWireProvider(),
+            };
+        }
+
+        private string ResolveWireEnrollMode() {
+            if (_selectedSigner == null) return null;
+            bool cert = _selectedSigner.EnrollToCertEnabled;
+            bool token = _selectedSigner.EnrollToTokenEnabled;
+            if (!cert && token) return "token";
+            if (_enrollMode == "device-certificate") return "cert";
+            if (_enrollMode == "user-session" && token) return "token";
+            return null;
+        }
+
+        private string ResolveWireProvider() {
+            return _showSignerPicker ? _selectedSigner?.Name : null;
         }
 
         public event PropertyChangedEventHandler PropertyChanged;
@@ -109,7 +154,6 @@ namespace ZitiDesktopEdge {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
-        // Map camelCase wire fields to PascalCase C# properties without per-field attributes.
         private static readonly JsonSerializerSettings DeserializationSettings = new JsonSerializerSettings {
             ContractResolver = new CamelCasePropertyNamesContractResolver()
         };

--- a/DesktopEdge/ViewModels/AddIdentityViewModel.cs
+++ b/DesktopEdge/ViewModels/AddIdentityViewModel.cs
@@ -1,0 +1,145 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace ZitiDesktopEdge {
+    /// <summary>Subset of the controller's external-jwt-signer response used by the add-identity UI.</summary>
+    public class ExternalJwtSigner {
+        public string Name { get; set; }
+        public bool EnrollToCertEnabled { get; set; }
+        public bool EnrollToTokenEnabled { get; set; }
+        public bool SupportsAnyEnrollMode => EnrollToCertEnabled || EnrollToTokenEnabled;
+    }
+
+    public class AddIdentityViewModel : INotifyPropertyChanged {
+        // Fixed by the Ziti edge API contract. The deployment-specific path prefix
+        // (e.g. "/edge/client/v1") is read from the controller's root response instead.
+        private const string EdgeClientApiFamily = "edge-client";
+        private const string EdgeClientApiVersion = "v1";
+        private const string ExternalJwtSignersSuffix = "/external-jwt-signers";
+        private static readonly TimeSpan DiscoveryTimeout = TimeSpan.FromSeconds(5);
+
+        private ExternalJwtSigner _selectedSigner;
+        private string _enrollMode;
+        private bool _isDiscovering;
+
+        public ObservableCollection<ExternalJwtSigner> Signers { get; } = new ObservableCollection<ExternalJwtSigner>();
+
+        public ExternalJwtSigner SelectedSigner {
+            get { return _selectedSigner; }
+            set {
+                _selectedSigner = value;
+                OnPropertyChanged(nameof(SelectedSigner));
+            }
+        }
+
+        public string EnrollMode {
+            get { return _enrollMode; }
+            set {
+                _enrollMode = value;
+                OnPropertyChanged(nameof(EnrollMode));
+            }
+        }
+
+        public bool IsDiscovering {
+            get { return _isDiscovering; }
+            private set {
+                _isDiscovering = value;
+                OnPropertyChanged(nameof(IsDiscovering));
+            }
+        }
+
+        /// <summary>
+        /// Replaces <see cref="Signers"/> with the controller's external JWT signers.
+        /// The caller provides the already-fetched preflight body so we don't re-GET the root.
+        /// HTTP and parsing errors propagate.
+        /// </summary>
+        public async Task DiscoverSignersAsync(string controllerUrl, string controllerRootBody) {
+            Signers.Clear();
+            SelectedSigner = null;
+            IsDiscovering = true;
+            try {
+                Uri baseUri = new Uri(controllerUrl);
+                string edgeClientPath = ExtractEdgeClientApiPath(controllerRootBody, baseUri);
+                Uri signersUri = new Uri(baseUri, edgeClientPath + ExternalJwtSignersSuffix);
+
+                using (HttpClient client = new HttpClient()) {
+                    client.Timeout = DiscoveryTimeout;
+                    string signersBody = await client.GetStringAsync(signersUri);
+                    ExternalJwtSignerListResponse parsed = JsonConvert.DeserializeObject<ExternalJwtSignerListResponse>(signersBody, DeserializationSettings);
+                    if (parsed?.Data != null) {
+                        foreach (ExternalJwtSigner signer in parsed.Data) {
+                            Signers.Add(signer);
+                        }
+                    }
+                }
+            } finally {
+                IsDiscovering = false;
+            }
+        }
+
+        private static string ExtractEdgeClientApiPath(string rootBody, Uri baseUri) {
+            ControllerRootResponse root = JsonConvert.DeserializeObject<ControllerRootResponse>(rootBody, DeserializationSettings);
+
+            Dictionary<string, ApiVersionInfo> edgeClient = null;
+            root?.Data?.ApiVersions?.TryGetValue(EdgeClientApiFamily, out edgeClient);
+            ApiVersionInfo v1 = null;
+            edgeClient?.TryGetValue(EdgeClientApiVersion, out v1);
+
+            if (string.IsNullOrEmpty(v1?.Path)) {
+                throw new InvalidOperationException(
+                    $"Controller at {baseUri} did not advertise an '{EdgeClientApiFamily}.{EdgeClientApiVersion}.path' in its root response.");
+            }
+            return v1.Path;
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected void OnPropertyChanged(string propertyName) {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        // Map camelCase wire fields to PascalCase C# properties without per-field attributes.
+        private static readonly JsonSerializerSettings DeserializationSettings = new JsonSerializerSettings {
+            ContractResolver = new CamelCasePropertyNamesContractResolver()
+        };
+
+        private class ControllerRootResponse {
+            public ControllerRootData Data { get; set; }
+        }
+
+        private class ControllerRootData {
+            public Dictionary<string, Dictionary<string, ApiVersionInfo>> ApiVersions { get; set; }
+        }
+
+        private class ApiVersionInfo {
+            public string Path { get; set; }
+        }
+
+        private class ExternalJwtSignerListResponse {
+            public List<ExternalJwtSigner> Data { get; set; }
+        }
+    }
+}

--- a/DesktopEdge/Views/Controls/AddIdentitySignerChoice.xaml
+++ b/DesktopEdge/Views/Controls/AddIdentitySignerChoice.xaml
@@ -1,0 +1,77 @@
+<!--
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+-->
+<UserControl x:Class="ZitiDesktopEdge.AddIdentitySignerChoice"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:ZitiDesktopEdge"
+             mc:Ignorable="d"
+             d:Width="400">
+    <Grid Margin="0" Height="Auto" VerticalAlignment="Center">
+        <Border Background="{StaticResource DarkBackgroundBrush}"
+                BorderBrush="Gray"
+                BorderThickness="2"
+                CornerRadius="10"
+                Padding="10" />
+        <StackPanel Margin="5,10,5,10">
+            <Label Content="Configure Enrollment" Foreground="White" FontSize="16" HorizontalAlignment="Center" FontWeight="Bold" />
+            <Label Content="Choose how this identity connects to the network" Foreground="White" Opacity="0.7" FontSize="12" HorizontalAlignment="Center" Margin="0,0,0,10" />
+
+            <Label Content="Identity Provider"
+                   Foreground="White" Opacity="0.7" FontSize="12"
+                   HorizontalAlignment="Center"
+                   Visibility="{Binding SignerPickerVisibility}" />
+            <ComboBox x:Name="SignerPicker"
+                      ItemsSource="{Binding Signers}"
+                      SelectedItem="{Binding SelectedSigner}"
+                      DisplayMemberPath="Name"
+                      Visibility="{Binding SignerPickerVisibility}"
+                      Background="White" Foreground="Black"
+                      FontSize="12" Padding="8,2"
+                      HorizontalAlignment="Center" HorizontalContentAlignment="Center"
+                      Width="200" Margin="0,0,0,15" />
+
+            <StackPanel x:Name="EnrollModePanel"
+                        Orientation="Vertical"
+                        HorizontalAlignment="Center"
+                        Visibility="{Binding EnrollModeRadiosVisibility}"
+                        Margin="0,0,0,15">
+                <RadioButton GroupName="EnrollMode"
+                             IsChecked="{Binding IsUserSessionSelected}"
+                             Foreground="White" Margin="0,2">
+                    <StackPanel>
+                        <TextBlock Text="User session" FontSize="12" />
+                        <TextBlock Text="requires periodic login, tied to user account"
+                                   FontSize="10" Opacity="0.7" />
+                    </StackPanel>
+                </RadioButton>
+                <RadioButton GroupName="EnrollMode"
+                             IsChecked="{Binding IsDeviceCertificateSelected}"
+                             Foreground="White" Margin="0,2">
+                    <StackPanel>
+                        <TextBlock Text="Device certificate" FontSize="12" />
+                        <TextBlock Text="no re-auth, tied to this machine"
+                                   FontSize="10" Opacity="0.7" />
+                    </StackPanel>
+                </RadioButton>
+            </StackPanel>
+
+            <local:StyledButton x:Name="JoinNetworkBtn" OnClick="JoinNetworkUrl" Label="Join Network" />
+        </StackPanel>
+        <Image Source="/Assets/Images/close.png" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,20,20,0" Width="15" Height="15" Cursor="Hand" MouseUp="ExecuteClose" />
+    </Grid>
+</UserControl>

--- a/DesktopEdge/Views/Controls/AddIdentitySignerChoice.xaml.cs
+++ b/DesktopEdge/Views/Controls/AddIdentitySignerChoice.xaml.cs
@@ -1,0 +1,45 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+using System;
+using System.Windows.Controls;
+using System.Windows.Input;
+using ZitiDesktopEdge.DataStructures;
+
+namespace ZitiDesktopEdge {
+    public partial class AddIdentitySignerChoice : UserControl {
+        public event CommonDelegates.CloseAction OnClose;
+        public event Action<EnrollIdentifierPayload, UserControl> OnAddIdentity;
+
+        public AddIdentitySignerChoice() {
+            InitializeComponent();
+        }
+
+        public void Prepare(AddIdentityViewModel viewModel) {
+            DataContext = viewModel;
+        }
+
+        private void JoinNetworkUrl(object sender, MouseButtonEventArgs e) {
+            AddIdentityViewModel vm = DataContext as AddIdentityViewModel;
+            if (vm == null || !vm.CanJoin) return;
+            OnAddIdentity?.Invoke(vm.BuildEnrollPayload(), this);
+        }
+
+        private void ExecuteClose(object sender, MouseButtonEventArgs e) {
+            this.OnClose?.Invoke(false, this);
+        }
+    }
+}

--- a/DesktopEdge/Views/Controls/AddIdentityUrl.xaml
+++ b/DesktopEdge/Views/Controls/AddIdentityUrl.xaml
@@ -72,17 +72,6 @@
             <!-- A place for a name, might be needed? -->
             <!--Label Content="Identity Alias" Foreground="White" Opacity="0.7" FontSize="12" HorizontalAlignment="Center"/>
                 <TextBox x:Name="IdentityName" FontSize="14" TextAlignment="Center" BorderThickness="0" Margin="0,0,0,15" /-->
-            <Label Content="Identity Provider"
-                   Foreground="White" Opacity="0.7" FontSize="12"
-                   HorizontalAlignment="Center"
-                   Visibility="{Binding SignerPickerVisibility}" />
-            <ComboBox x:Name="SignerPicker"
-                      ItemsSource="{Binding Signers}"
-                      SelectedItem="{Binding SelectedSigner}" DisplayMemberPath="Name"
-                      Visibility="{Binding SignerPickerVisibility}" Background="White"
-                      Foreground="Black" FontSize="12" Padding="8,2"
-                      HorizontalAlignment="Center" HorizontalContentAlignment="Center"
-                      Width="200" Margin="0,0,0,15" />
             <local:StyledButton x:Name="JoinNetworkBtn" OnClick="JoinNetworkUrl" Label="Join Network" />
 
         </StackPanel>

--- a/DesktopEdge/Views/Controls/AddIdentityUrl.xaml
+++ b/DesktopEdge/Views/Controls/AddIdentityUrl.xaml
@@ -58,7 +58,7 @@
             <Label Content="Controller URL" Foreground="White" FontSize="16" HorizontalAlignment="Center" FontWeight="Bold"/>
             <Label Content="Enter the controller URL" Foreground="White" Opacity="0.7" FontSize="12" HorizontalAlignment="Center"/>
             <TextBox x:Name="ControllerURL" 
-                             Text="https://controller.url" 
+                             Text="{Binding UrlPlaceholder, Mode=OneTime}"
                              Focusable="True"
                              FontSize="14" 
                              TextAlignment="Center" 
@@ -72,6 +72,17 @@
             <!-- A place for a name, might be needed? -->
             <!--Label Content="Identity Alias" Foreground="White" Opacity="0.7" FontSize="12" HorizontalAlignment="Center"/>
                 <TextBox x:Name="IdentityName" FontSize="14" TextAlignment="Center" BorderThickness="0" Margin="0,0,0,15" /-->
+            <Label Content="Identity Provider"
+                   Foreground="White" Opacity="0.7" FontSize="12"
+                   HorizontalAlignment="Center"
+                   Visibility="{Binding SignerPickerVisibility}" />
+            <ComboBox x:Name="SignerPicker"
+                      ItemsSource="{Binding Signers}"
+                      SelectedItem="{Binding SelectedSigner}" DisplayMemberPath="Name"
+                      Visibility="{Binding SignerPickerVisibility}" Background="White"
+                      Foreground="Black" FontSize="12" Padding="8,2"
+                      HorizontalAlignment="Center" HorizontalContentAlignment="Center"
+                      Width="200" Margin="0,0,0,15" />
             <local:StyledButton x:Name="JoinNetworkBtn" OnClick="JoinNetworkUrl" Label="Join Network" />
 
         </StackPanel>

--- a/DesktopEdge/Views/Controls/AddIdentityUrl.xaml.cs
+++ b/DesktopEdge/Views/Controls/AddIdentityUrl.xaml.cs
@@ -22,7 +22,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media.Animation;
-using System.Windows.Threading;
 using Windows.Web.Http;
 using ZitiDesktopEdge.DataStructures;
 
@@ -31,33 +30,39 @@ namespace ZitiDesktopEdge {
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
         public event CommonDelegates.CloseAction OnClose;
         public event Action<EnrollIdentifierPayload, UserControl> OnAddIdentity;
+        public event Action<AddIdentityViewModel, UserControl> OnNeedsSignerChoice;
 
         public CommonDelegates.JoinNetwork JoinNetwork;
 
         public AddIdentityViewModel AddIdentityViewModel { get; } = new AddIdentityViewModel();
 
-        // Fires RunDiscoveryAsync after the user stops typing in the URL field.
-        private readonly DispatcherTimer _discoveryDebounce = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(1500) };
-
         public AddIdentityUrl() {
             InitializeComponent();
             DataContext = AddIdentityViewModel;
-            _discoveryDebounce.Tick += DiscoveryDebounce_Tick;
         }
 
-        private async void DiscoveryDebounce_Tick(object sender, EventArgs e) {
-            _discoveryDebounce.Stop();
-            await RunDiscoveryAsync();
-        }
+        private async void JoinNetworkUrl(object sender, MouseButtonEventArgs e) {
+            if (!IsUrlSyntacticallyValid()) return;
 
-        private void JoinNetworkUrl(object sender, MouseButtonEventArgs e) {
-            // Button is only enabled after RunDiscoveryAsync succeeds, so we can trust the VM state here.
+            bool ok = await RunDiscoveryAsync();
+            if (!ok) {
+                this.OnClose?.Invoke(false, this);
+                return;
+            }
+
             Uri raw = new Uri(ControllerURL.Text);
-            string controllerBaseUrl = raw.GetLeftPart(UriPartial.Authority);
-            EnrollIdentifierPayload payload = new EnrollIdentifierPayload();
-            payload.ControllerURL = controllerBaseUrl;
-            payload.IdentityFilename = raw.Host + "_" + raw.Port;
-            OnAddIdentity(payload, this);
+            AddIdentityViewModel.ControllerBaseUrl = raw.GetLeftPart(UriPartial.Authority);
+            AddIdentityViewModel.IdentityFilename = raw.Host + "_" + raw.Port;
+
+            bool needsChoice = AddIdentityViewModel.ShowSignerPicker
+                            || AddIdentityViewModel.EnrollModeRadiosVisibility == Visibility.Visible
+                            || (AddIdentityViewModel.SelectedSigner != null && AddIdentityViewModel.SelectedSigner.EnrollToTokenEnabled);
+            if (needsChoice) {
+                OnNeedsSignerChoice?.Invoke(AddIdentityViewModel, this);
+                return;
+            }
+
+            OnAddIdentity(AddIdentityViewModel.BuildEnrollPayload(), this);
         }
 
         private async Task<bool> RunDiscoveryAsync() {
@@ -72,7 +77,6 @@ namespace ZitiDesktopEdge {
                 result.EnsureSuccessStatusCode();
                 string body = await result.Content.ReadAsStringAsync();
                 AddIdentityViewModel.LoadSigners(body);
-                JoinNetworkBtn.Enable();
                 return true;
             } catch (Exception ex) {
                 await ShowConnectionErrorAsync(ex);
@@ -116,26 +120,22 @@ namespace ZitiDesktopEdge {
 
         private void Grid_Loaded(object sender, System.Windows.RoutedEventArgs e) {
             ControllerURL.Focus();
-            // Remains disabled until RunDiscoveryAsync succeeds.
-            JoinNetworkBtn.Disable();         }
+            JoinNetworkBtn.Disable();
+        }
 
         private void ControllerURL_TextChanged(object sender, TextChangedEventArgs e) {
             if (ControllerURL.ActualWidth > 0) {
-                ControllerURL.MaxWidth = ControllerURL.ActualWidth; //disable any expanding
+                ControllerURL.MaxWidth = ControllerURL.ActualWidth;
             }
-            // URL changed: any prior discovery is stale, so invalidate state and disable Join until re-run.
             AddIdentityViewModel.Reset();
-            if (JoinNetworkBtn != null) JoinNetworkBtn.Disable();
             UpdateUrlValidity();
-            // Restart the debounce. Discovery fires after the user pauses typing.
-            // Skip the on-load placeholder so opening the dialog doesn't fire a request.
-            _discoveryDebounce.Stop();
-            if (IsUrlSyntacticallyValid() && ControllerURL.Text != AddIdentityViewModel.UrlPlaceholder) _discoveryDebounce.Start();
         }
 
         private void UpdateUrlValidity() {
-            if (IsUrlSyntacticallyValid()) {
+            bool valid = IsUrlSyntacticallyValid() && ControllerURL.Text != AddIdentityViewModel.UrlPlaceholder;
+            if (valid) {
                 ControllerURL.Style = (Style)Resources["ValidUrl"];
+                if (JoinNetworkBtn != null) JoinNetworkBtn.Enable();
             } else {
                 ControllerURL.Style = (Style)Resources["InvalidUrl"];
                 if (JoinNetworkBtn != null) JoinNetworkBtn.Disable();
@@ -143,8 +143,6 @@ namespace ZitiDesktopEdge {
         }
 
         private void HandleEnterKey(object sender, KeyEventArgs e) {
-            // Enter submits only once discovery has enabled the button. Before that it does nothing
-            // the debounce is already running to trigger discovery.
             if (e.Key == Key.Return && JoinNetworkBtn.IsEnabled) {
                 e.Handled = true;
                 JoinNetworkUrl(sender, null);

--- a/DesktopEdge/Views/Controls/AddIdentityUrl.xaml.cs
+++ b/DesktopEdge/Views/Controls/AddIdentityUrl.xaml.cs
@@ -22,6 +22,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media.Animation;
+using System.Windows.Threading;
 using Windows.Web.Http;
 using ZitiDesktopEdge.DataStructures;
 
@@ -35,49 +36,77 @@ namespace ZitiDesktopEdge {
 
         public AddIdentityViewModel AddIdentityViewModel { get; } = new AddIdentityViewModel();
 
+        // Fires RunDiscoveryAsync after the user stops typing in the URL field.
+        private readonly DispatcherTimer _discoveryDebounce = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(1500) };
+
         public AddIdentityUrl() {
             InitializeComponent();
+            DataContext = AddIdentityViewModel;
+            _discoveryDebounce.Tick += DiscoveryDebounce_Tick;
         }
 
-        private async void JoinNetworkUrl(object sender, MouseButtonEventArgs e) {
-            Uri raw = new Uri(ControllerURL.Text);
-            // Ignore any path/query the user pasted; we only want scheme://host:port.
-            string controllerBaseUrl = raw.GetLeftPart(UriPartial.Authority);
+        private async void DiscoveryDebounce_Tick(object sender, EventArgs e) {
+            _discoveryDebounce.Stop();
+            await RunDiscoveryAsync();
+        }
 
+        private void JoinNetworkUrl(object sender, MouseButtonEventArgs e) {
+            // Button is only enabled after RunDiscoveryAsync succeeds, so we can trust the VM state here.
+            Uri raw = new Uri(ControllerURL.Text);
+            string controllerBaseUrl = raw.GetLeftPart(UriPartial.Authority);
             EnrollIdentifierPayload payload = new EnrollIdentifierPayload();
             payload.ControllerURL = controllerBaseUrl;
             payload.IdentityFilename = raw.Host + "_" + raw.Port;
+            OnAddIdentity(payload, this);
+        }
 
-            var client = new System.Net.Http.HttpClient();
-            client.Timeout = TimeSpan.FromSeconds(5);
-
+        private async Task<bool> RunDiscoveryAsync() {
+            if (!IsUrlSyntacticallyValid()) return false;
             Mouse.OverrideCursor = Cursors.Wait;
             try {
-                var result = await client.GetAsync(controllerBaseUrl + "/external-jwt-signers");
+                Uri raw = new Uri(ControllerURL.Text);
+                string baseUrl = raw.GetLeftPart(UriPartial.Authority);
+                var client = new System.Net.Http.HttpClient();
+                client.Timeout = TimeSpan.FromSeconds(5);
+                var result = await client.GetAsync(baseUrl + "/external-jwt-signers");
                 result.EnsureSuccessStatusCode();
-                string signersBody = await result.Content.ReadAsStringAsync();
-                AddIdentityViewModel.LoadSigners(signersBody);
-                Mouse.OverrideCursor = null;
-                OnAddIdentity(payload, this);
+                string body = await result.Content.ReadAsStringAsync();
+                AddIdentityViewModel.LoadSigners(body);
+                JoinNetworkBtn.Enable();
+                return true;
             } catch (Exception ex) {
+                await ShowConnectionErrorAsync(ex);
+                return false;
+            } finally {
                 Mouse.OverrideCursor = null;
-                this.OnClose?.Invoke(false, this);
-                MainWindow mw = ((MainWindow)Application.Current.MainWindow);
-                if (ex.InnerException is System.Net.WebException webEx) {
-                    if (webEx.Status == System.Net.WebExceptionStatus.TrustFailure) {
-                        await mw.ShowBlurbAsync("Untrusted certificate or TLS error", "");
-                        logger.Warn(ex, "TLS trust issue with URL: {0}", ControllerURL.Text);
-                    } else if (webEx.Status == System.Net.WebExceptionStatus.NameResolutionFailure) {
-                        await mw.ShowBlurbAsync("Invalid or unreachable host name", "");
-                        logger.Warn(ex, "Bunk URL or DNS resolution failed: {0}", ControllerURL.Text);
-                    } else {
-                        await mw.ShowBlurbAsync("Unexpected error accessing URL", "");
-                        logger.Warn(ex, "Could not connect to URL, status={0}", webEx.Status);
-                    }
+            }
+        }
+
+        private async Task ShowConnectionErrorAsync(Exception ex) {
+            MainWindow mw = (MainWindow)Application.Current.MainWindow;
+            if (ex.InnerException is System.Net.WebException webEx) {
+                if (webEx.Status == System.Net.WebExceptionStatus.TrustFailure) {
+                    await mw.ShowBlurbAsync("Untrusted certificate or TLS error", "");
+                    logger.Warn(ex, "TLS trust issue with URL: {0}", ControllerURL.Text);
+                } else if (webEx.Status == System.Net.WebExceptionStatus.NameResolutionFailure) {
+                    await mw.ShowBlurbAsync("Invalid or unreachable host name", "");
+                    logger.Warn(ex, "Bunk URL or DNS resolution failed: {0}", ControllerURL.Text);
                 } else {
                     await mw.ShowBlurbAsync("Unexpected error accessing URL", "");
-                    logger.Warn(ex, "Unexpected exception {0}", ex.Message);
+                    logger.Warn(ex, "Could not connect to URL, status={0}", webEx.Status);
                 }
+            } else {
+                await mw.ShowBlurbAsync("Unexpected error accessing URL", "");
+                logger.Warn(ex, "Unexpected exception {0}", ex.Message);
+            }
+        }
+
+        private bool IsUrlSyntacticallyValid() {
+            try {
+                Uri ctrl = new Uri(ControllerURL.Text);
+                return ctrl.Host.Contains(".") && ctrl.Host.Length >= 3;
+            } catch {
+                return false;
             }
         }
 
@@ -87,40 +116,40 @@ namespace ZitiDesktopEdge {
 
         private void Grid_Loaded(object sender, System.Windows.RoutedEventArgs e) {
             ControllerURL.Focus();
-        }
+            // Remains disabled until RunDiscoveryAsync succeeds.
+            JoinNetworkBtn.Disable();         }
 
         private void ControllerURL_TextChanged(object sender, TextChangedEventArgs e) {
             if (ControllerURL.ActualWidth > 0) {
                 ControllerURL.MaxWidth = ControllerURL.ActualWidth; //disable any expanding
             }
+            // URL changed: any prior discovery is stale, so invalidate state and disable Join until re-run.
+            AddIdentityViewModel.Reset();
+            if (JoinNetworkBtn != null) JoinNetworkBtn.Disable();
             UpdateUrlValidity();
+            // Restart the debounce. Discovery fires after the user pauses typing.
+            // Skip the on-load placeholder so opening the dialog doesn't fire a request.
+            _discoveryDebounce.Stop();
+            if (IsUrlSyntacticallyValid() && ControllerURL.Text != AddIdentityViewModel.UrlPlaceholder) _discoveryDebounce.Start();
         }
 
         private void UpdateUrlValidity() {
-            bool valid = true;
-            try {
-                // check that it looks like a url
-                Uri ctrl = new Uri(ControllerURL.Text);
-                if (!ctrl.Host.Contains(".") || ctrl.Host.Length < 3) {
-                    valid = false;
-                }
-            } catch {
-                // not a url -- don't allow it
-                valid = false;
-            }
-            if(valid) {
+            if (IsUrlSyntacticallyValid()) {
                 ControllerURL.Style = (Style)Resources["ValidUrl"];
-                if (JoinNetworkBtn != null) JoinNetworkBtn.Enable();
             } else {
                 ControllerURL.Style = (Style)Resources["InvalidUrl"];
                 if (JoinNetworkBtn != null) JoinNetworkBtn.Disable();
             }
         }
+
         private void HandleEnterKey(object sender, KeyEventArgs e) {
-            if (e.Key == Key.Return) {
+            // Enter submits only once discovery has enabled the button. Before that it does nothing
+            // the debounce is already running to trigger discovery.
+            if (e.Key == Key.Return && JoinNetworkBtn.IsEnabled) {
                 e.Handled = true;
-                this.JoinNetworkUrl(sender, null);
+                JoinNetworkUrl(sender, null);
             }
         }
+
     }
 }

--- a/DesktopEdge/Views/Controls/AddIdentityUrl.xaml.cs
+++ b/DesktopEdge/Views/Controls/AddIdentityUrl.xaml.cs
@@ -79,6 +79,7 @@ namespace ZitiDesktopEdge {
                 AddIdentityViewModel.LoadSigners(body);
                 return true;
             } catch (Exception ex) {
+                logger.Error(ex, "connecting to the url provided failed");
                 await ShowConnectionErrorAsync(ex);
                 return false;
             } finally {

--- a/DesktopEdge/Views/Controls/AddIdentityUrl.xaml.cs
+++ b/DesktopEdge/Views/Controls/AddIdentityUrl.xaml.cs
@@ -33,23 +33,30 @@ namespace ZitiDesktopEdge {
 
         public CommonDelegates.JoinNetwork JoinNetwork;
 
+        public AddIdentityViewModel AddIdentityViewModel { get; } = new AddIdentityViewModel();
+
         public AddIdentityUrl() {
             InitializeComponent();
         }
 
         private async void JoinNetworkUrl(object sender, MouseButtonEventArgs e) {
-            EnrollIdentifierPayload payload = new EnrollIdentifierPayload();
-            payload.ControllerURL = ControllerURL.Text;
+            Uri raw = new Uri(ControllerURL.Text);
+            // Ignore any path/query the user pasted; we only want scheme://host:port.
+            string controllerBaseUrl = raw.GetLeftPart(UriPartial.Authority);
 
-            Uri ctrl = new Uri(ControllerURL.Text);
-            payload.IdentityFilename = ctrl.Host + "_" + ctrl.Port;
+            EnrollIdentifierPayload payload = new EnrollIdentifierPayload();
+            payload.ControllerURL = controllerBaseUrl;
+            payload.IdentityFilename = raw.Host + "_" + raw.Port;
 
             var client = new System.Net.Http.HttpClient();
             client.Timeout = TimeSpan.FromSeconds(5);
 
             Mouse.OverrideCursor = Cursors.Wait;
             try {
-                var result = await client.GetAsync(ControllerURL.Text);
+                var result = await client.GetAsync(controllerBaseUrl + "/external-jwt-signers");
+                result.EnsureSuccessStatusCode();
+                string signersBody = await result.Content.ReadAsStringAsync();
+                AddIdentityViewModel.LoadSigners(signersBody);
                 Mouse.OverrideCursor = null;
                 OnAddIdentity(payload, this);
             } catch (Exception ex) {

--- a/DesktopEdge/ZitiDesktopEdge.csproj
+++ b/DesktopEdge/ZitiDesktopEdge.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Models\ViewState.cs" />
     <Compile Include="Utils\ManagedSettingsReader.cs" />
     <Compile Include="ViewModels\ManagedSettingsViewModel.cs" />
+    <Compile Include="ViewModels\AddIdentityViewModel.cs" />
     <Compile Include="ViewModels\MainViewModel.cs" />
     <Compile Include="ViewModels\IdentityDetailsViewModel.cs" />
     <Compile Include="Views\Controls\ConfirmationDialog.xaml.cs">

--- a/DesktopEdge/ZitiDesktopEdge.csproj
+++ b/DesktopEdge/ZitiDesktopEdge.csproj
@@ -157,6 +157,9 @@
     <Compile Include="Views\Controls\AddIdentityUrl.xaml.cs">
       <DependentUpon>AddIdentityUrl.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\Controls\AddIdentitySignerChoice.xaml.cs">
+      <DependentUpon>AddIdentitySignerChoice.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\Controls\ExternalProviderSelector.xaml.cs">
       <DependentUpon>ExternalProviderSelector.xaml</DependentUpon>
     </Compile>
@@ -230,6 +233,10 @@
       <Generator>XamlIntelliSenseFileGenerator</Generator>
     </Page>
     <Page Include="Views\Controls\AddIdentityUrl.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Views\Controls\AddIdentitySignerChoice.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/DesktopEdge/ZitiDesktopEdge.csproj
+++ b/DesktopEdge/ZitiDesktopEdge.csproj
@@ -295,6 +295,7 @@
     <Compile Include="Views\ItemRenderers\IdentityItem.xaml.cs">
       <DependentUpon>IdentityItem.xaml</DependentUpon>
     </Compile>
+    <Compile Include="TunnelInstancePickerWindow.cs" />
     <Compile Include="MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/ZitiDesktopEdge.Client/DataStructures/DataStructures.cs
+++ b/ZitiDesktopEdge.Client/DataStructures/DataStructures.cs
@@ -245,6 +245,8 @@ namespace ZitiDesktopEdge.DataStructures {
         public string Key { get; set; }
         public string Certificate { get; set; }
         public string ControllerURL { get; set; }
+        public string EnrollMode { get; set; }
+        public string Provider { get; set; }
     }
 
     public class EnrollIdentifierFunction : ServiceFunction {

--- a/ZitiDesktopEdge.Client/DataStructures/DataStructures.cs
+++ b/ZitiDesktopEdge.Client/DataStructures/DataStructures.cs
@@ -291,6 +291,9 @@ namespace ZitiDesktopEdge.DataStructures {
         public DateTime MfaLastUpdatedTime { get; set; }
         public bool NeedsExtAuth { get; set; }
         public List<string> ExtAuthProviders { get; set; }
+        // Populated on the AddIdentity response when enrollment needs external auth — zet returns
+        // the OIDC authorize URL so ZDEW can open the browser for the user to sign in.
+        public string Url { get; set; }
     }
 
     public class Service {

--- a/ZitiDesktopEdge.Client/ServiceClient/AbstractClient.cs
+++ b/ZitiDesktopEdge.Client/ServiceClient/AbstractClient.cs
@@ -42,6 +42,31 @@ namespace ZitiDesktopEdge.ServiceClient {
 
         protected NamedPipeClientStream pipeClient = null;
         protected NamedPipeClientStream eventClient = null;
+
+        /// <summary>
+        /// Set by subclasses during an in-flight instance switch. When true, the
+        /// disconnect path must not kick off the auto-reconnect loop or fire the
+        /// OnClientDisconnected event — the caller is orchestrating the swap and
+        /// will reconnect to a new pipe explicitly.
+        /// </summary>
+        protected volatile bool SwitchInProgress;
+
+        /// <summary>
+        /// Monotonic counter bumped every time the live pipe pair is replaced
+        /// (reconnect, or explicit instance switch). Each event-reader task
+        /// captures the value when it starts and only reports its own
+        /// disconnection if the counter still matches on exit — stale readers
+        /// from a prior connection stay silent.
+        /// </summary>
+        private int _connectionGeneration;
+
+        protected int BumpConnectionGeneration() {
+            return System.Threading.Interlocked.Increment(ref _connectionGeneration);
+        }
+
+        protected int CurrentConnectionGeneration {
+            get { return System.Threading.Volatile.Read(ref _connectionGeneration); }
+        }
         protected StreamWriter ipcWriter = null;
         protected StreamReader ipcReader = null;
         protected abstract Task ConnectPipesAsync();
@@ -63,6 +88,7 @@ namespace ZitiDesktopEdge.ServiceClient {
             ExpectedShutdown = false;
             Logger.Debug("Client connected successfully. Setting UnexpectedShutdown set to false.");
 
+            int readerGen = BumpConnectionGeneration();
             ipcWriter = new StreamWriter(pipeClient);
             ipcReader = new StreamReader(pipeClient);
             Task.Run(async () => { //hack for now until it's async...
@@ -74,7 +100,7 @@ namespace ZitiDesktopEdge.ServiceClient {
                             }
                             string respAsString = null;
                             try {
-                                respAsString = await readMessageAsync("event", eventReader);
+                                respAsString = await readMessageAsync("event", eventReader, readerGen);
                                 try {
                                     ProcessLine(respAsString);
                                 } catch (Exception ex) {
@@ -89,8 +115,16 @@ namespace ZitiDesktopEdge.ServiceClient {
                     Logger.Debug("unepxected error: " + ex.ToString());
                 }
 
-                // since this thread is always sitting waiting to read
-                // it should be the only one triggering this event
+                // Only report the disconnect if we're still the active reader.
+                // A SwitchInstanceAsync (or any other force-replace of the pipe
+                // pair) bumps the generation; the stale reader's async callback
+                // can land long after the new connection is live, so comparing
+                // generations keeps it from kicking off a spurious reconnect
+                // cycle.
+                if (readerGen != CurrentConnectionGeneration) {
+                    Logger.Debug("stale event-reader exit ignored (readerGen={0}, current={1})", readerGen, CurrentConnectionGeneration);
+                    return;
+                }
                 ClientDisconnected(null);
             });
             OnClientConnected?.Invoke(this, e);
@@ -170,6 +204,18 @@ namespace ZitiDesktopEdge.ServiceClient {
             await ConnectPipesAsync();
         }
 
+        /// <summary>
+        /// Set by <see cref="AbortReconnect"/> to ask an in-flight reconnect
+        /// loop to bail out. Checked after each Task.Delay so an external
+        /// caller taking over the pipe pair (e.g. an explicit instance
+        /// switch) doesn't race against the retry loop.
+        /// </summary>
+        private volatile bool _abortReconnect;
+
+        public void AbortReconnect() {
+            _abortReconnect = true;
+        }
+
         public void Reconnect() {
             if (Reconnecting) {
                 Logger.Debug("Already in reconnect mode.");
@@ -177,6 +223,7 @@ namespace ZitiDesktopEdge.ServiceClient {
             } else {
                 Reconnecting = true;
             }
+            _abortReconnect = false;
 
             Task.Run(async () => {
                 Logger.Info("service is down. attempting to connect to service...");
@@ -184,9 +231,16 @@ namespace ZitiDesktopEdge.ServiceClient {
                 DateTime reconnectStart = DateTime.Now;
                 DateTime logAgainAfter = reconnectStart + TimeSpan.FromSeconds(1);
 
-                while (true) {
+                while (!_abortReconnect) {
                     try {
                         await Task.Delay(2500);
+                        if (_abortReconnect) break;
+                        if (Connected) {
+                            // Someone else (e.g. SwitchInstanceAsync) connected
+                            // while we were sleeping. Exit quietly.
+                            Reconnecting = false;
+                            return;
+                        }
                         await ConnectPipesAsync();
 
                         if (Connected) {
@@ -219,6 +273,7 @@ namespace ZitiDesktopEdge.ServiceClient {
                         }
                     }
                 }
+                Reconnecting = false;
             });
         }
 
@@ -271,6 +326,20 @@ namespace ZitiDesktopEdge.ServiceClient {
         }
 
         async public Task<string> readMessageAsync(string channel, StreamReader reader) {
+            return await readMessageAsync(channel, reader, null);
+        }
+
+        /// <summary>
+        /// Same as <see cref="readMessageAsync(string, StreamReader)"/> but
+        /// with optional generation awareness. Callers running as part of a
+        /// long-lived reader task (e.g. the event channel) should pass the
+        /// generation captured when the reader started. If the pipe was
+        /// replaced beneath us (instance switch, reconnect) we no longer own
+        /// the stream and must not fire ClientDisconnected — that would kick
+        /// off a redundant reconnect cycle on top of the one already in
+        /// flight.
+        /// </summary>
+        async public Task<string> readMessageAsync(string channel, StreamReader reader, int? readerGeneration) {
             try {
                 int emptyCount = 1; //just a stop gap in case something crazy happens in the communication
 
@@ -291,15 +360,28 @@ namespace ZitiDesktopEdge.ServiceClient {
                 return respAsString;
             } catch (IOException ioe) {
                 //almost certainly a problem with the pipe
-                Logger.Error(ioe, "io error in read: " + ioe.Message);
-                ClientDisconnected(null);
+                if (IsCurrentReader(readerGeneration)) {
+                    Logger.Error(ioe, "io error in read: " + ioe.Message);
+                    ClientDisconnected(null);
+                } else {
+                    Logger.Debug("io error from stale reader ignored (gen={0}, current={1}): {2}", readerGeneration, CurrentConnectionGeneration, ioe.Message);
+                }
                 throw ioe;
             } catch (Exception ee) {
                 //almost certainly a problem with the pipe
-                Logger.Error(ee, "unexpected error in read: " + ee.Message);
-                ClientDisconnected(null);
+                if (IsCurrentReader(readerGeneration)) {
+                    Logger.Error(ee, "unexpected error in read: " + ee.Message);
+                    ClientDisconnected(null);
+                } else {
+                    Logger.Debug("read error from stale reader ignored (gen={0}, current={1}): {2}", readerGeneration, CurrentConnectionGeneration, ee.Message);
+                }
                 throw ee;
             }
+        }
+
+        private bool IsCurrentReader(int? readerGeneration) {
+            if (!readerGeneration.HasValue) return true; // caller opted out of the check
+            return readerGeneration.Value == CurrentConnectionGeneration;
         }
 
         async public Task WaitForConnectionAsync() {

--- a/ZitiDesktopEdge.Client/ServiceClient/AbstractClient.cs
+++ b/ZitiDesktopEdge.Client/ServiceClient/AbstractClient.cs
@@ -322,6 +322,15 @@ namespace ZitiDesktopEdge.ServiceClient {
                     };
             }
 
+            // EnrollMode and Provider are optional AddIdentity fields; omit them when unset so the payload
+            // stays wire-compatible with zet builds that predate them.
+            if (property.DeclaringType == typeof(EnrollIdentifierPayload) && property.PropertyName == "EnrollMode") {
+                property.ShouldSerialize = instance => !string.IsNullOrEmpty(((EnrollIdentifierPayload)instance)?.EnrollMode);
+            }
+            if (property.DeclaringType == typeof(EnrollIdentifierPayload) && property.PropertyName == "Provider") {
+                property.ShouldSerialize = instance => !string.IsNullOrEmpty(((EnrollIdentifierPayload)instance)?.Provider);
+            }
+
             return property;
         }
     }

--- a/ZitiDesktopEdge.Client/ServiceClient/AbstractClient.cs
+++ b/ZitiDesktopEdge.Client/ServiceClient/AbstractClient.cs
@@ -322,13 +322,19 @@ namespace ZitiDesktopEdge.ServiceClient {
                     };
             }
 
-            // EnrollMode and Provider are optional AddIdentity fields; omit them when unset so the payload
-            // stays wire-compatible with zet builds that predate them.
             if (property.DeclaringType == typeof(EnrollIdentifierPayload) && property.PropertyName == "EnrollMode") {
-                property.ShouldSerialize = instance => !string.IsNullOrEmpty(((EnrollIdentifierPayload)instance)?.EnrollMode);
+                property.ShouldSerialize =
+                    instance => {
+                        EnrollIdentifierPayload payload = (EnrollIdentifierPayload)instance;
+                        return payload != null && !string.IsNullOrEmpty(payload.EnrollMode);
+                    };
             }
             if (property.DeclaringType == typeof(EnrollIdentifierPayload) && property.PropertyName == "Provider") {
-                property.ShouldSerialize = instance => !string.IsNullOrEmpty(((EnrollIdentifierPayload)instance)?.Provider);
+                property.ShouldSerialize =
+                    instance => {
+                        EnrollIdentifierPayload payload = (EnrollIdentifierPayload)instance;
+                        return payload != null && !string.IsNullOrEmpty(payload.Provider);
+                    };
             }
 
             return property;

--- a/ZitiDesktopEdge.Client/ServiceClient/DataClient.cs
+++ b/ZitiDesktopEdge.Client/ServiceClient/DataClient.cs
@@ -101,16 +101,88 @@ namespace ZitiDesktopEdge.ServiceClient {
         }
 
         protected override void ClientDisconnected(object e) {
+            if (SwitchInProgress) {
+                // The caller is orchestrating an instance switch — stay quiet; they
+                // will call ConnectPipesAsync again against the new pipe names.
+                Connected = false;
+                return;
+            }
             Reconnect();
             Connected = false;
             base.ClientDisconnected(e);
         }
 
         // ziti edge tunnel
-        const string ipcPipe = @"ziti-edge-tunnel.sock";
-        const string eventPipe = @"ziti-edge-tunnel-event.sock";
+        private const string DefaultIpcPipe = @"ziti-edge-tunnel.sock";
+        private const string DefaultEventPipe = @"ziti-edge-tunnel-event.sock";
 
-        public DataClient(string id) : base(id) {
+        private string ipcPipe;
+        private string eventPipe;
+
+        /// <summary>
+        /// The discriminator supplied to ziti-edge-tunnel via its -P|--pipe flag.
+        /// null (or empty) means the default instance (no discriminator).
+        /// </summary>
+        public string Discriminator { get; private set; }
+
+        public DataClient(string id) : this(id, null) {
+        }
+
+        public DataClient(string id, string discriminator) : base(id) {
+            ApplyDiscriminator(discriminator);
+        }
+
+        private void ApplyDiscriminator(string discriminator) {
+            Discriminator = string.IsNullOrEmpty(discriminator) ? null : discriminator;
+            if (Discriminator == null) {
+                ipcPipe = DefaultIpcPipe;
+                eventPipe = DefaultEventPipe;
+            } else {
+                ipcPipe = DefaultIpcPipe + "." + Discriminator;
+                eventPipe = DefaultEventPipe + "." + Discriminator;
+            }
+        }
+
+        /// <summary>
+        /// Switch this client from the currently-connected ziti-edge-tunnel
+        /// instance to the one identified by <paramref name="discriminator"/>
+        /// (null/empty means the default instance). The caller is responsible
+        /// for resetting any UI state tied to the previous instance BEFORE
+        /// calling this — the normal OnClientDisconnected event is suppressed
+        /// while the swap is in progress so the UI does not flash "service not
+        /// started".
+        ///
+        /// On return the new pipes are connected and event delivery has
+        /// resumed; a fresh TunnelStatusEvent will repopulate identities.
+        /// </summary>
+        public async Task SwitchInstanceAsync(string discriminator) {
+            string newDisc = string.IsNullOrEmpty(discriminator) ? null : discriminator;
+            if (newDisc == Discriminator && Connected) {
+                return;
+            }
+
+            // Ask any background reconnect loop to bail out — we're about to
+            // take the pipes over. Without this, the loop can race with our
+            // own ConnectPipesAsync and produce a parallel event reader.
+            AbortReconnect();
+
+            SwitchInProgress = true;
+            try {
+                // Bump generation BEFORE disposing so the stale event-reader
+                // task — which may take tens of milliseconds to notice the
+                // dispose — sees a mismatch when it exits and stays silent.
+                BumpConnectionGeneration();
+                try { pipeClient?.Dispose(); } catch (Exception ex) { Logger.Debug(ex, "error disposing pipeClient during switch"); }
+                try { eventClient?.Dispose(); } catch (Exception ex) { Logger.Debug(ex, "error disposing eventClient during switch"); }
+                pipeClient = null;
+                eventClient = null;
+                Connected = false;
+                ApplyDiscriminator(newDisc);
+            } finally {
+                SwitchInProgress = false;
+            }
+
+            await ConnectPipesAsync();
         }
 
         PipeSecurity CreateSystemIOPipeSecurity() {

--- a/ZitiDesktopEdge.Client/ServiceClient/TunnelInstanceDiscovery.cs
+++ b/ZitiDesktopEdge.Client/ServiceClient/TunnelInstanceDiscovery.cs
@@ -1,0 +1,250 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Newtonsoft.Json.Linq;
+using NLog;
+
+namespace ZitiDesktopEdge.ServiceClient {
+    /// <summary>
+    /// Discovers all ziti-edge-tunnel.exe instances running on the local machine by
+    /// enumerating named pipes of the form:
+    ///   \\.\pipe\ziti-edge-tunnel.sock              (default instance)
+    ///   \\.\pipe\ziti-edge-tunnel.sock.&lt;discriminator&gt;  (-P &lt;discriminator&gt; instance)
+    ///
+    /// For each matching pipe the discovery performs a best-effort "Status" probe to
+    /// pull TunName/IP/DNS. Instances are returned even if the probe fails so the UI
+    /// can present "something is listening there" to the user.
+    /// </summary>
+    public class TunnelInstanceDiscovery {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+        private const string DefaultPipeName = "ziti-edge-tunnel.sock";
+        private const string DefaultEventPipeName = "ziti-edge-tunnel-event.sock";
+        private static readonly Regex PipeNameRegex = new Regex(
+            @"^ziti-edge-tunnel\.sock(?:\.(.+))?$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        public class TunnelInstance {
+            public string Discriminator { get; set; }
+            public string DisplayLabel {
+                get { return string.IsNullOrEmpty(Discriminator) ? "default" : Discriminator; }
+            }
+            public string PipeName { get; set; }
+            public string EventPipeName { get; set; }
+            public string TunName { get; set; }
+            public string Ip { get; set; }
+            public string Dns { get; set; }
+
+            /// <summary>
+            /// True when this instance was discovered by enumerating live named
+            /// pipes. False for synthetic entries (e.g. the "default" row the
+            /// picker always shows even if the default pipe isn't active).
+            /// </summary>
+            public bool IsOnline { get; set; } = true;
+        }
+
+        /// <summary>
+        /// Construct a synthetic "default" TunnelInstance marked as offline.
+        /// Used by the picker so the default row is always visible even when
+        /// the default ziti-edge-tunnel isn't running — letting the user
+        /// come back to it after starting the service.
+        /// </summary>
+        public static TunnelInstance OfflineDefault() {
+            return new TunnelInstance {
+                Discriminator = null,
+                PipeName = "ziti-edge-tunnel.sock",
+                EventPipeName = "ziti-edge-tunnel-event.sock",
+                IsOnline = false,
+            };
+        }
+
+        /// <summary>
+        /// Enumerate all ziti-edge-tunnel instances currently running on the local
+        /// machine. Each discovered instance is probed in parallel with a short
+        /// timeout so total enumeration time is bounded by probeTimeoutMs rather
+        /// than N * probeTimeoutMs.
+        /// </summary>
+        public static async Task<IReadOnlyList<TunnelInstance>> EnumerateAsync(int probeTimeoutMs = 150, CancellationToken ct = default(CancellationToken)) {
+            List<TunnelInstance> instances = new List<TunnelInstance>();
+
+            string[] pipeEntries;
+            try {
+                // On Windows .NET Framework, Directory.GetFiles against \\.\pipe\
+                // returns the list of named pipes. Entries come back as full paths
+                // of the form \\.\pipe\<name>, so we extract just the name.
+                pipeEntries = Directory.GetFiles(@"\\.\pipe\");
+            } catch (Exception ex) {
+                Logger.Debug(ex, "Failed to enumerate named pipes at \\\\.\\pipe\\");
+                return instances;
+            }
+
+            foreach (string entry in pipeEntries) {
+                if (string.IsNullOrEmpty(entry)) continue;
+                string name = entry;
+                int lastSlash = name.LastIndexOf('\\');
+                if (lastSlash >= 0 && lastSlash < name.Length - 1) {
+                    name = name.Substring(lastSlash + 1);
+                }
+
+                Match m = PipeNameRegex.Match(name);
+                if (!m.Success) continue;
+
+                string discriminator = m.Groups[1].Success ? m.Groups[1].Value : null;
+
+                // Skip the event pipes - we only want the command pipes. The event
+                // pipe name contains "-event" which is not matched by our regex,
+                // but this guard is here defensively in case the regex is ever
+                // loosened.
+                if (!string.IsNullOrEmpty(discriminator) && discriminator.StartsWith("sock", StringComparison.OrdinalIgnoreCase)) {
+                    continue;
+                }
+
+                TunnelInstance inst = new TunnelInstance {
+                    Discriminator = discriminator,
+                    PipeName = string.IsNullOrEmpty(discriminator)
+                        ? DefaultPipeName
+                        : DefaultPipeName + "." + discriminator,
+                    EventPipeName = string.IsNullOrEmpty(discriminator)
+                        ? DefaultEventPipeName
+                        : DefaultEventPipeName + "." + discriminator,
+                };
+                instances.Add(inst);
+            }
+
+            // De-duplicate in case Directory.GetFiles returns an event pipe that
+            // somehow satisfied the regex (the event pipe name ends with
+            // -event.sock, which does not match ^ziti-edge-tunnel\.sock, so this
+            // is belt-and-braces only).
+            instances = instances
+                .GroupBy(i => i.PipeName, StringComparer.OrdinalIgnoreCase)
+                .Select(g => g.First())
+                .ToList();
+
+            if (instances.Count == 0) {
+                return instances;
+            }
+
+            Task[] probes = instances
+                .Select(i => ProbeAsync(i, probeTimeoutMs, ct))
+                .ToArray();
+            try {
+                await Task.WhenAll(probes).ConfigureAwait(false);
+            } catch (Exception ex) {
+                // Individual probe failures are swallowed inside ProbeAsync; this
+                // only trips for truly unexpected exceptions.
+                Logger.Debug(ex, "unexpected error while awaiting tunnel instance probes");
+            }
+
+            return instances;
+        }
+
+        private static async Task ProbeAsync(TunnelInstance inst, int probeTimeoutMs, CancellationToken ct) {
+            NamedPipeClientStream pipe = null;
+            try {
+                pipe = new NamedPipeClientStream(".", inst.PipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+
+                // NamedPipeClientStream.ConnectAsync in .NET Framework 4.8 exists,
+                // but it does not natively honor a cancellation token on the
+                // underlying connect. We wrap with a timeout Task so the probe is
+                // bounded. Any failure here just means "probe failed" - the
+                // instance still goes into the returned list.
+                Task connectTask = pipe.ConnectAsync(probeTimeoutMs);
+                Task delayTask = Task.Delay(probeTimeoutMs + 50, ct);
+                Task winner = await Task.WhenAny(connectTask, delayTask).ConfigureAwait(false);
+                if (winner != connectTask || !pipe.IsConnected) {
+                    Logger.Debug("probe: connect timed out for pipe '{0}'", inst.PipeName);
+                    return;
+                }
+                await connectTask.ConfigureAwait(false); // surface any connect exception
+
+                // Write the Status command.
+                byte[] payload = new UTF8Encoding(false).GetBytes("{\"Command\":\"Status\"}\n");
+                using (var cts = CancellationTokenSource.CreateLinkedTokenSource(ct)) {
+                    cts.CancelAfter(probeTimeoutMs);
+                    await pipe.WriteAsync(payload, 0, payload.Length, cts.Token).ConfigureAwait(false);
+                    await pipe.FlushAsync(cts.Token).ConfigureAwait(false);
+                }
+
+                // Read a single line back. Leave the stream open so the pipe is
+                // closed cleanly by the using below.
+                StreamReader reader = new StreamReader(pipe, new UTF8Encoding(false), false, 4096, true);
+                Task<string> readTask = reader.ReadLineAsync();
+                Task readTimeout = Task.Delay(probeTimeoutMs, ct);
+                Task readWinner = await Task.WhenAny(readTask, readTimeout).ConfigureAwait(false);
+                if (readWinner != readTask) {
+                    Logger.Debug("probe: read timed out for pipe '{0}'", inst.PipeName);
+                    return;
+                }
+
+                string line = await readTask.ConfigureAwait(false);
+                if (string.IsNullOrWhiteSpace(line)) {
+                    Logger.Debug("probe: empty response from pipe '{0}'", inst.PipeName);
+                    return;
+                }
+
+                try {
+                    // Status response envelope (ziti-tunnel-sdk-c):
+                    //   { Success, Error, Code, Data: { TunName, IpInfo: { Ip, DNS }, ... } }
+                    // Fields confirmed from
+                    //   lib/ziti-tunnel-cbs/include/ziti/ziti_tunnel_cbs.h:96-100
+                    //   programs/ziti-edge-tunnel/include/model/dtos.h:101-117
+                    JObject obj = JObject.Parse(line);
+                    JObject data = obj.GetValue("Data", StringComparison.OrdinalIgnoreCase) as JObject;
+                    if (data == null) {
+                        Logger.Debug("probe: status response for pipe '{0}' had no Data object. payload={1}", inst.PipeName, line);
+                        return;
+                    }
+
+                    inst.TunName = GetStringProp(data, "TunName");
+
+                    JObject ipInfo = data.GetValue("IpInfo", StringComparison.OrdinalIgnoreCase) as JObject;
+                    if (ipInfo != null) {
+                        inst.Ip = GetStringProp(ipInfo, "Ip");
+                        inst.Dns = GetStringProp(ipInfo, "DNS");
+                    }
+                } catch (Exception ex) {
+                    Logger.Debug(ex, "probe: failed to parse JSON response from pipe '{0}'. payload={1}", inst.PipeName, line);
+                }
+            } catch (OperationCanceledException) {
+                Logger.Debug("probe: canceled for pipe '{0}'", inst.PipeName);
+            } catch (Exception ex) {
+                Logger.Debug(ex, "probe: unexpected error for pipe '{0}'", inst.PipeName);
+            } finally {
+                try { pipe?.Dispose(); } catch { /* ignore */ }
+            }
+        }
+
+        private static string GetStringProp(JObject obj, string name) {
+            if (obj == null) return null;
+            JToken tok = obj.GetValue(name, StringComparison.OrdinalIgnoreCase);
+            if (tok == null || tok.Type == JTokenType.Null || tok.Type == JTokenType.Object || tok.Type == JTokenType.Array) {
+                return null;
+            }
+            string s = tok.ToString();
+            return string.IsNullOrEmpty(s) ? null : s;
+        }
+    }
+}

--- a/ZitiDesktopEdge.Client/ServiceClient/TunnelInstanceDiscovery.cs
+++ b/ZitiDesktopEdge.Client/ServiceClient/TunnelInstanceDiscovery.cs
@@ -95,7 +95,7 @@ namespace ZitiDesktopEdge.ServiceClient {
                 // On Windows .NET Framework, Directory.GetFiles against \\.\pipe\
                 // returns the list of named pipes. Entries come back as full paths
                 // of the form \\.\pipe\<name>, so we extract just the name.
-                pipeEntries = Directory.GetFiles(@"\\.\pipe\");
+                pipeEntries = Directory.GetFiles(@"\\.\pipe\", "ziti*");
             } catch (Exception ex) {
                 Logger.Debug(ex, "Failed to enumerate named pipes at \\\\.\\pipe\\");
                 return instances;

--- a/ZitiDesktopEdge.Client/ZitiDesktopEdge.Client.csproj
+++ b/ZitiDesktopEdge.Client/ZitiDesktopEdge.Client.csproj
@@ -76,6 +76,7 @@
     <Compile Include="DataStructures\DataStructures.cs" />
     <Compile Include="ServiceClient\MonitorClient.cs" />
     <Compile Include="Utility\ByteFormat.cs" />
+    <Compile Include="ServiceClient\TunnelInstanceDiscovery.cs" />
     <Compile Include="Utility\GithubAPI.cs" />
     <Compile Include="Utility\UpgradeSentinel.cs" />
   </ItemGroup>

--- a/upcoming-release-notes.md
+++ b/upcoming-release-notes.md
@@ -1,88 +1,17 @@
-# Release 2.11.0.0
+# Next Release
 ## What's New
-* [Issue 985](https://github.com/openziti/desktop-edge-win/issues/985) - Allow registry settings to override and lock ZDEW local/file settings
-  * Organizational policy enforcement via the Windows registry
-      * IT administrators can enforce settings via Group Policy, Microsoft Intune with the
-        provided ADMX ingested, or any tool that writes directly to the managed-policy hive:
-        `HKLM\SOFTWARE\Policies\NetFoundry\Ziti Desktop Edge for Windows\`
-      * Registry values take precedence over `settings.json` and `App.config` defaults; if no
-        registry value is present, behavior is unchanged from prior releases
-      * Values live under `HKLM\SOFTWARE\Policies\...`, which the Group Policy Client Side
-        Extension manages directly. When a GPO is unlinked or no longer applies to the
-        machine, the corresponding values are removed automatically and the lock is released
-      * Policy is enforced server-side by `ziti-monitor-service` -- any IPC attempt to mutate a
-        locked setting is rejected with a new `MANAGED_BY_POLICY` error code
-      * The UI reads policy state from the monitor service at connect time and on every status
-        event, disables locked controls, and shows a "Managed by your organization" banner on
-        the Automatic Upgrades page
-      * A WMI registry tree watcher detects policy writes, changes, and removals live -- no
-        service restart is required when an admin applies or revokes policy
-      * A startup poll timer (5 s x up to 24 attempts, ~2 min total) handles the Group Policy
-        boot-race where policy may not yet have applied by the time the service starts
-      * Some values have enforced bounds (`UpdateTimer` >= 600 s,
-        `AlivenessChecksBeforeAction` >= 1, `MaintenanceWindowStart`/`MaintenanceWindowEnd` 0-23).
-        Values outside the bounds are adjusted to the nearest allowed value and the
-        effective value is logged
-      * Settings controllable under `ziti-monitor-service`:
-          * `AutomaticUpdatesDisabled` (DWORD) -- enable/disable automatic update checks
-          * `AutomaticUpdateURL` (String) -- pin the update stream to a specific URL
-          * `UpdateTimer` (DWORD, seconds) -- update-check interval (minimum 600 s)
-          * `InstallationReminder` (DWORD, seconds) -- reminder countdown for pending updates
-          * `InstallationCritical` (DWORD, seconds) -- deadline after which a pending update is forced
-          * `AlivenessChecksBeforeAction` (DWORD) -- missed heartbeats before tunnel restart (min 1)
-          * `DeferInstallToRestart` (DWORD) -- force all updates to be staged until next restart
-          * `MaintenanceWindowStart` (DWORD, 0-23) -- start hour of the allowed install window
-          * `MaintenanceWindowEnd` (DWORD, 0-23) -- end hour (equal to start means "any time")
-      * Settings controllable under `ui`:
-          * `DefaultExtAuthProvider` (String) -- pins the default external auth provider in the
-            identity enrollment screen; the provider selector is disabled when set
-  * Maintenance window
-      * Administrators (via policy) or users (when not policy-locked) can configure a daily hour
-        range during which automatic installs are permitted
-      * Updates that arrive outside the window are held and applied when the window next opens
-      * Equal start/end hours means "any time" (no windowing)
-      * Exposed in the Automatic Upgrades settings page with two hour-selector combo boxes
-  * Defer install until next system restart
-      * Users (via the Automatic Upgrades page) or administrators (via the `DeferInstallToRestart`
-        policy) can opt to stage an update rather than install immediately
-      * When deferred, the installer is downloaded and validated in the background
-      * Staged installs are registered as a Task Scheduler task under
-        `Task Scheduler Library\NetFoundry\ZitiDesktopEdge-PendingUpdate`, running as SYSTEM at
-        next startup with highest privileges
-      * The task is removed automatically if policy later disables automatic updates,
-        and at next service startup once the staged installer has run
-  * New `MonitorServiceStatusEvent` fields broadcast policy lock state and deferred-install state
-    to the UI, including `*Locked` booleans for every policy-controllable setting,
-    `MaintenanceWindowStart/End`, `DeferredInstallPending`, `DeferToRestartPending`, and
-    `StagingDownloadPending`
-  * New IPC operations on the monitor service: `setmaintenancewindowstart`,
-    `setmaintenancewindowend`; `TriggerUpdate` now accepts a `forceDefer` parameter so the UI
-    can request a staged install explicitly
-  * ADMX/ADML Group Policy templates for `ziti-monitor-service` and the UI, ready for GPMC or
-    Intune ADMX ingestion. Bundled as `ZDEW-AdminTemplates-<version>.zip` on each GitHub release.
-  * PowerShell helper script (`Set-PolicyRegistryValues.ps1`) for setting policy registry values
-    directly without a full GPO deployment -- useful for standalone machines or test rigs
-  * Per-identity external authentication provider selection is policy-locked when
-    `DefaultExtAuthProvider` is set under the `ui` key
-* [Issue 970](https://github.com/openziti/desktop-edge-win/issues/970) - Added toast notifications for external auth success/failure when the UI is minimized and auto-launch browser for single-provider external auth
+* Enroll to cert / token via external JWT signers
+    * Joining a network by URL now discovers the controller's external JWT signers and routes
+      enrollment through them when applicable
+    * If the controller has no external signers, behavior is unchanged
+    * If a single signer is offered with a single mode, the user is taken straight through
+    * If a choice is required (multiple signers, or one signer that supports both cert and
+      token enrollment), a new picker dialog appears
+    * When the controller asks the user to authenticate in a browser, ZDEW launches it and
+      the identity arrives once sign-in completes
 
 ## Bugs fixed
-* [Issue 776](https://github.com/openziti/desktop-edge-win/issues/776) - Feedback collection no longer times out prematurely on large or verbose log bundles
-    * Progress dialog shows the current phase (copy, collect, zip) and bundle size
-    * Stall detection: if the service stops sending progress for 10 seconds the UI surfaces an error
-    * A notice is shown when feedback is requested while a previous collection is still in progress
-    * Error dialog reports the underlying error rather than always saying "monitor service is offline"
-    * Symlinked log files are skipped, and a duplicate ZET log copy step was removed
+n/a
 
 ## Other changes
-* Dependency bumps: NLog 5 -> 6, Newtonsoft.Json 13.0.3 -> 13.0.4, System.CodeDom 8 -> 10,
-  DnsClient 1.7 -> 1.8, Microsoft.Windows.SDK.Contracts 26100 -> 28000; added
-  `Microsoft.Bcl.Cryptography` and `System.Formats.Asn1`
-* Advanced Installer project upgraded 23.2 -> 23.6; installer now emits an MSI SHA256 sidecar
-  alongside the EXE
-
-## Dependencies
-* ziti-tunneler: v1.16.1
-* ziti-sdk:      1.16.0
-* tlsuv:         v0.41.3[OpenSSL 3.6.1 27 Jan 2026]
-* tlsuv:         v0.41.3[win32crypto(CNG): ncrypt[1.0] ]
+n/a


### PR DESCRIPTION
Adds support for enrolling identities through a controller's external JWT signers when joining a network by URL. The preflight that used to be a bare GET now hits `/external-jwt-signers` so we know what enrollment path the controller expects, and the UI adapts:

- No signers: same flow as before.
- One signer, one mode: silent passthrough, no extra dialog.
- Multiple signers, or a signer that supports both cert and token: a new picker dialog asks the user to choose.
- Controller wants browser-based auth: the browser is launched and the identity flows in through the normal event channel after sign-in.
- Closes #958

This branch also carries multi tun support, exposed as a hidden **Ctrl+Shift+T** picker. It is dev-only, not user-facing