### PR TITLE
Fix "Any time" maintenance window ignoring the chosen day

### DIFF
--- a/DesktopEdge/Views/Screens/MainMenu.xaml.cs
+++ b/DesktopEdge/Views/Screens/MainMenu.xaml.cs
@@ -183,39 +183,12 @@ namespace ZitiDesktopEdge {
             }
 
             if (state.PendingUpdate.TimeLeft > 0) {
-                DateTime installTime = SnapInstallTimeToWindow(state.PendingUpdate.InstallTime);
-                UpdateTimeLeft.Content = $"Automatic update to {state.PendingUpdate.Version} will occur on or after {installTime.ToString("g")}";
+                UpdateTimeLeft.Content = $"Automatic update to {state.PendingUpdate.Version} will occur on or after {state.PendingUpdate.InstallTime.ToString("g")}";
                 UpdateTimeLeft.Visibility = Visibility.Visible;
                 CheckForUpdateStatus.Content = $"update {state.PendingUpdate.Version} is available";
                 CheckForUpdateStatus.Visibility = Visibility.Visible;
             }
             SetAutomaticUpgradesState();
-        }
-
-        /// <summary>
-        /// Snaps <paramref name="installTime"/> forward to the next opening of the current
-        /// maintenance window. Returns it unchanged when no window is set (any time).
-        /// Mirrors the same logic in UpdateService so the UI stays correct even before
-        /// the service sends a fresh InstallationNotificationEvent after a window change.
-        /// </summary>
-        private DateTime SnapInstallTimeToWindow(DateTime installTime) {
-            int? start = policyViewModel.MaintenanceWindowStart;
-            int? end   = policyViewModel.MaintenanceWindowEnd;
-            if (!start.HasValue || !end.HasValue) return installTime;
-            if (start.Value == end.Value) return installTime;  // 0/0 or equal = any time
-
-            if (IsInMaintenanceWindow(installTime.Hour, start.Value, end.Value)) return installTime;
-
-            DateTime candidate = installTime.Date.AddHours(start.Value);
-            if (candidate <= installTime) candidate = candidate.AddDays(1);
-            return candidate;
-        }
-
-        private bool IsInMaintenanceWindow(int hour, int windowStart, int windowEnd) {
-            if (windowStart < windowEnd) {
-                return hour >= windowStart && hour < windowEnd;
-            }
-            return hour >= windowStart || hour < windowEnd;  // crosses midnight
         }
 
         internal MainWindow MainWindow { get; set; }

--- a/ZitiUpdateService.Tests/MaintenanceWindowMisconfigurationTests.cs
+++ b/ZitiUpdateService.Tests/MaintenanceWindowMisconfigurationTests.cs
@@ -180,11 +180,9 @@ namespace ZitiUpdateService.Tests {
         // 5. IsInWindow direct call with start == end. When start==end, the production code
         //    falls into the cross-midnight branch (`hour >= start || hour < end`), and since
         //    start==end that expression simplifies to `hour >= X || hour < X` which is
-        //    ALWAYS TRUE for any X. This matches the "any time" semantics used by callers.
-        //
-        //    Pinning this here means SnapToMaintenanceWindow's start==end short-circuit
-        //    (line 112 of the evaluator) and IsInWindow are in agreement: both treat
-        //    start==end as "every hour qualifies".
+        //    ALWAYS TRUE for any X. This is the "any time of day" half of the semantics:
+        //    every hour qualifies. The calendar-day cadence (Weekly/Monthly) is enforced
+        //    separately by IsCalendarDayQualifying, so start==end frees the hour only.
         // ---------------------------------------------------------------------------------
 
         [DataTestMethod]

--- a/ZitiUpdateService.Tests/MaintenanceWindowSnapTests.cs
+++ b/ZitiUpdateService.Tests/MaintenanceWindowSnapTests.cs
@@ -144,6 +144,31 @@ namespace ZitiUpdateService.Tests {
         }
 
         [TestMethod]
+        public void Snap_MonthlyByDateAnyTime_OnNonQualifyingDay_SkipsToNextMatchingDateAtMidnight() {
+            // Monthly ByDate=1, any-time. May 14 noon lands on June 1 at 00:00.
+            DateTime dt = new DateTime(2026, 5, 14, 12, 0, 0);
+            DateTime result = Snap(dt,
+                windowStart: 0, windowEnd: 0,
+                frequency: MaintenanceWindowFrequency.Monthly,
+                monthlyMode: MaintenanceWindowMonthlyMode.ByDate,
+                dayOfMonth: 1);
+            Assert.AreEqual(new DateTime(2026, 6, 1, 0, 0, 0), result);
+        }
+
+        [TestMethod]
+        public void Snap_MonthlyByWeekdayAnyTime_OnNonQualifyingDay_SkipsToNextOrdinalDayAtMidnight() {
+            // Third Tuesday, any-time. May 20 (after May's third Tuesday, the 19th) lands on June 16 at 00:00.
+            DateTime dt = new DateTime(2026, 5, 20, 12, 0, 0);
+            DateTime result = Snap(dt,
+                windowStart: 0, windowEnd: 0,
+                frequency: MaintenanceWindowFrequency.Monthly,
+                monthlyMode: MaintenanceWindowMonthlyMode.ByWeekday,
+                dayOfWeek: (int)DayOfWeek.Tuesday,
+                monthlyOrdinal: MaintenanceWindowMonthlyOrdinal.Third);
+            Assert.AreEqual(new DateTime(2026, 6, 16, 0, 0, 0), result);
+        }
+
+        [TestMethod]
         public void Snap_MonthlyByWeekday_ThirdTuesday_AfterCurrentMonthSlot_GoesToNextMonth() {
             // Third Tuesday of May 2026 is May 19. If dt is May 20 noon -> snap to next month's
             // Third Tuesday (June 16, 2026).

--- a/ZitiUpdateService.Tests/MaintenanceWindowSnapTests.cs
+++ b/ZitiUpdateService.Tests/MaintenanceWindowSnapTests.cs
@@ -122,6 +122,28 @@ namespace ZitiUpdateService.Tests {
         }
 
         [TestMethod]
+        public void Snap_WeeklyAnyTime_OnNonQualifyingDay_SkipsToNextQualifyingDayAtMidnight() {
+            // Any-time (start==end) frees the hour but the weekly day cadence still applies.
+            DateTime dt = new DateTime(2026, 5, 11, 12, 0, 0); // Monday
+            DateTime result = Snap(dt,
+                windowStart: 0, windowEnd: 0,
+                frequency: MaintenanceWindowFrequency.Weekly,
+                dayOfWeek: (int)DayOfWeek.Sunday);
+            Assert.AreEqual(new DateTime(2026, 5, 17, 0, 0, 0), result);
+            Assert.AreEqual(DayOfWeek.Sunday, result.DayOfWeek);
+        }
+
+        [TestMethod]
+        public void Snap_WeeklyAnyTime_OnQualifyingDay_ReturnsInputUnchanged() {
+            DateTime dt = new DateTime(2026, 5, 17, 14, 0, 0); // Sunday
+            DateTime result = Snap(dt,
+                windowStart: 0, windowEnd: 0,
+                frequency: MaintenanceWindowFrequency.Weekly,
+                dayOfWeek: (int)DayOfWeek.Sunday);
+            Assert.AreEqual(dt, result);
+        }
+
+        [TestMethod]
         public void Snap_MonthlyByWeekday_ThirdTuesday_AfterCurrentMonthSlot_GoesToNextMonth() {
             // Third Tuesday of May 2026 is May 19. If dt is May 20 noon -> snap to next month's
             // Third Tuesday (June 16, 2026).

--- a/ZitiUpdateService/UpdateService.cs
+++ b/ZitiUpdateService/UpdateService.cs
@@ -381,7 +381,7 @@ namespace ZitiUpdateService {
             int? start = PolicySettings.EffectiveMaintenanceWindowStart(CurrentSettings);
             int? end   = PolicySettings.EffectiveMaintenanceWindowEnd(CurrentSettings);
             bool anyTime = !start.HasValue || !end.HasValue || start.Value == end.Value;
-            bool inWindow = anyTime || IsCurrentlyInMaintenanceWindow();
+            bool inWindow = IsCurrentlyInMaintenanceWindow();
 
             Logger.Info("TriggerUpdate requested. MaintenanceWindow={0}-{1}, anyTime={2}, inWindow={3}, now={4}",
                 start.HasValue ? start.Value.ToString() : "null",
@@ -1567,10 +1567,10 @@ namespace ZitiUpdateService {
             int? start = PolicySettings.EffectiveMaintenanceWindowStart(CurrentSettings);
             int? end   = PolicySettings.EffectiveMaintenanceWindowEnd(CurrentSettings);
             if (!start.HasValue || !end.HasValue) return true;
-            if (start.Value == end.Value) return true;  // 0/0 or equal values = any time
 
             DateTime now = DateTime.Now;
             if (!IsCalendarDayQualifying(now)) return false;
+            if (start.Value == end.Value) return true;  // any time of day on a qualifying day
             return IsInWindow(now.Hour, start.Value, end.Value);
         }
 

--- a/ZitiUpdateService/UpdateService.cs
+++ b/ZitiUpdateService/UpdateService.cs
@@ -353,7 +353,25 @@ namespace ZitiUpdateService {
             CurrentSettings.MaintenanceWindowDayOfMonth     = req.DayOfMonth;
             CurrentSettings.MaintenanceWindowMonthlyOrdinal = req.MonthlyOrdinal;
             CurrentSettings.Write();
+            RefreshPendingInstallNotification();
             return new SvcResponse { Message = "Success" };
+        }
+
+        /// <summary>
+        /// Recomputes the pending update's projected install time against the current
+        /// maintenance window and pushes a fresh notification. Called after a window change
+        /// so the UI reflects the new schedule immediately instead of waiting for the next
+        /// update check. No-op when no update is pending (or updates are policy-disabled).
+        /// </summary>
+        private void RefreshPendingInstallNotification() {
+            InstallationNotificationEvent info = lastInstallationNotification;
+            if (info == null) return;
+            ApplyEffectiveSettings(info);
+            info.InstallTime = InstallationIsCritical(info.PublishTime)
+                ? SnapToMaintenanceWindow(DateTime.Now)
+                : InstallDateFromPublishDate(info.PublishTime);
+            Logger.Info("Maintenance window changed; recomputed install time for {0} to {1} (local)", info.ZDEVersion, info.InstallTime);
+            NotifyInstallationUpdates(info, true);
         }
 
         private SvcResponse SetAutomaticUpdateDisabled(bool disabled) {

--- a/ZitiUpdateService/utils/MaintenanceWindowEvaluator.cs
+++ b/ZitiUpdateService/utils/MaintenanceWindowEvaluator.cs
@@ -101,9 +101,8 @@ namespace ZitiUpdateService.Utils {
         /// to guarantee termination even with a pathological config; if no qualifying day is
         /// found inside the cap the input is returned unchanged.
         ///
-        /// "Any time" (windowStart == windowEnd) frees the hour but not the calendar-day
-        /// cadence: a Weekly/Monthly window still snaps to the next qualifying day, landing at
-        /// 00:00 since every hour of that day qualifies.
+        /// An "any time" window (windowStart == windowEnd) still honors the Weekly/Monthly
+        /// day cadence and lands at 00:00 of the next qualifying day.
         /// </summary>
         public static DateTime SnapToMaintenanceWindow(
                 DateTime dt,

--- a/ZitiUpdateService/utils/MaintenanceWindowEvaluator.cs
+++ b/ZitiUpdateService/utils/MaintenanceWindowEvaluator.cs
@@ -100,6 +100,10 @@ namespace ZitiUpdateService.Utils {
         /// then aligns the hour to <paramref name="windowStart"/>. Capped at one year forward
         /// to guarantee termination even with a pathological config; if no qualifying day is
         /// found inside the cap the input is returned unchanged.
+        ///
+        /// "Any time" (windowStart == windowEnd) frees the hour but not the calendar-day
+        /// cadence: a Weekly/Monthly window still snaps to the next qualifying day, landing at
+        /// 00:00 since every hour of that day qualifies.
         /// </summary>
         public static DateTime SnapToMaintenanceWindow(
                 DateTime dt,
@@ -109,18 +113,19 @@ namespace ZitiUpdateService.Utils {
                 int? dayOfWeek, int? dayOfMonth,
                 MaintenanceWindowMonthlyOrdinal? monthlyOrdinal) {
             if (!windowStart.HasValue || !windowEnd.HasValue) return dt;
-            if (windowStart.Value == windowEnd.Value) return dt; // any time
 
+            bool anyTime = windowStart.Value == windowEnd.Value;
             bool dayQualifies = IsCalendarDayQualifying(dt, frequency, monthlyMode, dayOfWeek, dayOfMonth, monthlyOrdinal);
-            if (dayQualifies && IsInWindow(dt.Hour, windowStart.Value, windowEnd.Value)) return dt;
+            if (dayQualifies && (anyTime || IsInWindow(dt.Hour, windowStart.Value, windowEnd.Value))) return dt;
 
-            DateTime candidate = dt.Date.AddHours(windowStart.Value);
+            int snapHour = anyTime ? 0 : windowStart.Value;
+            DateTime candidate = dt.Date.AddHours(snapHour);
             if (candidate <= dt) candidate = candidate.AddDays(1);
 
             DateTime ceiling = dt.AddYears(1);
             while (candidate <= ceiling) {
                 if (IsCalendarDayQualifying(candidate, frequency, monthlyMode, dayOfWeek, dayOfMonth, monthlyOrdinal)) return candidate;
-                candidate = candidate.Date.AddDays(1).AddHours(windowStart.Value);
+                candidate = candidate.Date.AddDays(1).AddHours(snapHour);
             }
             return dt;
         }

--- a/upcoming-release-notes.md
+++ b/upcoming-release-notes.md
@@ -1,15 +1,9 @@
-# Release 2.11.2.4
+# Next Release
 ## What's New
-- Clicking "enable MFA" on an identity in the main UI now opens the MFA setup view directly when MFA needs to be enabled.
+n/a
 
 ## Bugs fixed
-- https://github.com/openziti/desktop-edge-win/issues/947
+- https://github.com/openziti/desktop-edge-win/issues/1018
 
 ## Other changes
 n/a
-
-## Dependencies
-* ziti-tunneler: v1.18.0
-* ziti-sdk:      1.18.0
-* tlsuv:         v0.41.3[OpenSSL 3.6.2 7 Apr 2026]
-* tlsuv:         v0.41.3[win32crypto(CNG): ncrypt[1.0] ]

--- a/upcoming-release-notes.md
+++ b/upcoming-release-notes.md
@@ -3,7 +3,7 @@
 n/a
 
 ## Bugs fixed
-- https://github.com/openziti/desktop-edge-win/issues/1018
+* [Issue 1018](https://github.com/openziti/desktop-edge-win/issues/1018) - Fix "Any time" maintenance window ignoring the configured day for automatic updates
 
 ## Other changes
 n/a


### PR DESCRIPTION
"Any time" was treated as "any day, any time," so a Weekly/Monthly window would schedule and report auto-installs on the wrong day. Now "Any time" frees only the hour: the install snaps forward to the next configured day.

Updated the main menu text label "Automatic update {version} will occur on or after {date/time}" to accurately reflect maintenance windows if set as well.

Closes #1018 