### PR TITLE
Prevent UI crash when a user clicks "application logs" with no UI log folder present

### DIFF
--- a/DesktopEdge/Views/Screens/MainMenu.xaml.cs
+++ b/DesktopEdge/Views/Screens/MainMenu.xaml.cs
@@ -378,8 +378,14 @@ namespace ZitiDesktopEdge {
             } else if (menuState == "UILogs") {
                 MenuTitle.Content = "Advanced Settings";
                 AdvancedItems.Visibility = Visibility.Visible;
-                OpenLogFile("UI", MainWindow.ExpectedLogPathUI);
                 BackArrow.Visibility = Visibility.Visible;
+                // UI log folder is provisioned by the monitor service. Clicking "application logs" after deleting the folder crashes the UI. See Issue #1029.
+                if (!Directory.Exists(Path.GetDirectoryName(MainWindow.ExpectedLogPathUI))) {
+                    logger.Error("UI log folder not found at {0}", MainWindow.ExpectedLogPathUI);
+                    this.OnShowBlurb?.Invoke("No UI log folder found");
+                    return;
+                }
+                OpenLogFile("UI", MainWindow.ExpectedLogPathUI);
             } else if (menuState == "LogLevel") {
                 ResetLevels();
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -4,6 +4,7 @@ n/a
 
 ## Bugs fixed
 * [Issue 1025](https://github.com/openziti/desktop-edge-win/issues/1025) - Skip the empty "Configure Enrollment" dialog when the controller offers a single enroll-to JWT signer
+* [Issue 1029](https://github.com/openziti/desktop-edge-win/issues/1029) - Prevent a UI crash when opening application logs while the UI log folder is missing
 
 ## Other changes
 n/a


### PR DESCRIPTION
Prevents the UI crash caused by #1029 