### PR TITLE
Fix identity details resizing and MFA recovery codes disappearing

### DIFF
--- a/DesktopEdge/MainWindow.xaml
+++ b/DesktopEdge/MainWindow.xaml
@@ -175,7 +175,7 @@
                 <ImageBrush ImageSource="/Assets/Images/background.png" />
             </Rectangle.Fill>
         </Rectangle>
-        <StackPanel x:Name="MainView" Margin="10,10,10,-20" MinHeight="580">
+        <StackPanel x:Name="MainView" Margin="10,10,10,-20" MinHeight="580" VerticalAlignment="Top">
             <Grid HorizontalAlignment="Stretch">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="100"/>

--- a/DesktopEdge/MainWindow.xaml
+++ b/DesktopEdge/MainWindow.xaml
@@ -175,7 +175,7 @@
                 <ImageBrush ImageSource="/Assets/Images/background.png" />
             </Rectangle.Fill>
         </Rectangle>
-        <StackPanel x:Name="MainView" Margin="10,10,10,-20" MinHeight="580" VerticalAlignment="Top">
+        <StackPanel x:Name="MainView" Margin="10,10,10,-10" MinHeight="580" VerticalAlignment="Top">
             <Grid HorizontalAlignment="Stretch">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="100"/>
@@ -399,6 +399,7 @@
         <!-- ID Detail UI -->
         <local:IdentityDetails x:Name="IdentityMenu"
                                Visibility="Collapsed"
+                               Height="{Binding ActualHeight, ElementName=MainView}"
                                d:Visibility="Visible"
                                OnMFAToggled="MFAToggled"
                                AuthenticateTOTP="ShowAuthenticate"

--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -2133,6 +2133,7 @@ namespace ZitiDesktopEdge {
 
         private void SetLocation() {
             var desktopWorkingArea = SystemParameters.WorkArea;
+            double renderedHeight = MainView.ActualHeight;
 
             Rectangle trayRectangle = WinAPI.GetTrayRectangle();
             if (trayRectangle.Top < 20) {
@@ -2146,25 +2147,15 @@ namespace ZitiDesktopEdge {
             } else if (desktopWorkingArea.Right == (double)trayRectangle.Left) {
                 this.Position = "Right";
                 this.Left = desktopWorkingArea.Right - this.Width - 20;
-                this.Top = desktopWorkingArea.Bottom - _mainViewHeight - 75;
+                this.Top = desktopWorkingArea.Bottom - renderedHeight - 75;
             } else {
                 this.Position = "Bottom";
                 this.Left = desktopWorkingArea.Right - this.Width - 75;
-                this.Top = desktopWorkingArea.Bottom - _mainViewHeight;
+                this.Top = desktopWorkingArea.Bottom - renderedHeight;
             }
         }
-        private double _mainViewHeight;
 
         public void Placement() {
-            // don't measure while an overlay is up, they feed their own height back (#1020)
-            if (IdentityMenu.Visibility != Visibility.Visible && MFASetup.Visibility != Visibility.Visible) {
-                _mainViewHeight = MainView.ActualHeight;
-            }
-            // MainHeight needs to track MainView's height even when detached, otherwise the
-            // Identity-detail scroll sizes from a stale value and pushes the Forget button
-            // off the bottom. SetLocation also positions the window against the tray, which
-            // only applies when docked.
-            IdentityMenu.MainHeight = _mainViewHeight;
             if (_isAttached) {
                 SetLocation();
             }

--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -2004,6 +2004,7 @@ namespace ZitiDesktopEdge {
                     IdentityItem item = (IdentityItem)IdList.Children[i];
                     item.StopTimers();
                 }
+                int previousIdentityCount = IdList.Children.Count;
                 IdList.Children.Clear();
                 var desktopWorkingArea = SystemParameters.WorkArea;
                 if (_maxHeight > (desktopWorkingArea.Height - 10)) {
@@ -2055,8 +2056,10 @@ namespace ZitiDesktopEdge {
                             if (id.Identifier == IdentityMenu.Identity.Identifier) IdentityMenu.Identity = id;
                         }
                     }
-                    // no animation, this runs on every identity event
-                    IdList.Height = ids.Length * 64;
+                    // animate only when the identity count changes, not on every event
+                    if (ids.Length != previousIdentityCount) {
+                        IdList.BeginAnimation(FrameworkElement.HeightProperty, new DoubleAnimation(IdList.ActualHeight, ids.Length * 64, TimeSpan.FromSeconds(.2)));
+                    }
                     IdListScroller.Visibility = Visibility.Visible;
                 } else {
                     // Make room for the welcome screen when it's about to show.

--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -2005,7 +2005,6 @@ namespace ZitiDesktopEdge {
                     item.StopTimers();
                 }
                 IdList.Children.Clear();
-                IdList.Height = 0;
                 var desktopWorkingArea = SystemParameters.WorkArea;
                 if (_maxHeight > (desktopWorkingArea.Height - 10)) {
                     _maxHeight = desktopWorkingArea.Height - 10;
@@ -2056,8 +2055,8 @@ namespace ZitiDesktopEdge {
                             if (id.Identifier == IdentityMenu.Identity.Identifier) IdentityMenu.Identity = id;
                         }
                     }
-                    DoubleAnimation animation = new DoubleAnimation((double)(ids.Length * 64), TimeSpan.FromSeconds(.2));
-                    IdList.BeginAnimation(FrameworkElement.HeightProperty, animation);
+                    // no animation, this runs on every identity event
+                    IdList.Height = ids.Length * 64;
                     IdListScroller.Visibility = Visibility.Visible;
                 } else {
                     // Make room for the welcome screen when it's about to show.
@@ -2135,9 +2134,6 @@ namespace ZitiDesktopEdge {
         private void SetLocation() {
             var desktopWorkingArea = SystemParameters.WorkArea;
 
-            var renderedHeight = MainView.ActualHeight;
-            IdentityMenu.MainHeight = renderedHeight;
-
             Rectangle trayRectangle = WinAPI.GetTrayRectangle();
             if (trayRectangle.Top < 20) {
                 this.Position = "Top";
@@ -2150,19 +2146,25 @@ namespace ZitiDesktopEdge {
             } else if (desktopWorkingArea.Right == (double)trayRectangle.Left) {
                 this.Position = "Right";
                 this.Left = desktopWorkingArea.Right - this.Width - 20;
-                this.Top = desktopWorkingArea.Bottom - renderedHeight - 75;
+                this.Top = desktopWorkingArea.Bottom - _mainViewHeight - 75;
             } else {
                 this.Position = "Bottom";
                 this.Left = desktopWorkingArea.Right - this.Width - 75;
-                this.Top = desktopWorkingArea.Bottom - renderedHeight;
+                this.Top = desktopWorkingArea.Bottom - _mainViewHeight;
             }
         }
+        private double _mainViewHeight;
+
         public void Placement() {
-            // MainHeight needs to track live window height even when detached, otherwise the
+            // don't measure while an overlay is up, they feed their own height back (#1020)
+            if (IdentityMenu.Visibility != Visibility.Visible && MFASetup.Visibility != Visibility.Visible) {
+                _mainViewHeight = MainView.ActualHeight;
+            }
+            // MainHeight needs to track MainView's height even when detached, otherwise the
             // Identity-detail scroll sizes from a stale value and pushes the Forget button
             // off the bottom. SetLocation also positions the window against the tray, which
             // only applies when docked.
-            IdentityMenu.MainHeight = MainView.ActualHeight;
+            IdentityMenu.MainHeight = _mainViewHeight;
             if (_isAttached) {
                 SetLocation();
             }

--- a/DesktopEdge/Views/Screens/IdentityDetails.xaml
+++ b/DesktopEdge/Views/Screens/IdentityDetails.xaml
@@ -74,12 +74,14 @@
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
-                <RowDefinition Height="1*"/>
-                <!-- Content before -->
-                <RowDefinition Height="*" />
-                <!-- Space for the StackPanel -->
+                <!-- header and identity fields -->
+                <RowDefinition Height="Auto"/>
+                <!-- service list -->
+                <RowDefinition Height="*"/>
+                <!-- forget button -->
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-            <StackPanel Grid.Column="0" Orientation="Vertical" HorizontalAlignment="Stretch" Margin="0,0,0,0">
+            <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Vertical" HorizontalAlignment="Stretch">
                 <!-- Header Controls -->
                 <Grid Margin="0,0,0,10">
                     <Grid.ColumnDefinitions>
@@ -142,8 +144,15 @@
                                       Margin="20,0,20,5" Recovery="MFARecovery" Authenticate="MFAAuthenticate"
                                       Toggle="ToggleMFA"></local:MenuEditToggle>
                 <local:Filter x:Name="FilterServices" OnFilter="DoFilter" VerticalAlignment="Top" Margin="10,5,10,0" />
-                <StackPanel Name="ServicesPanel" d:Visibility="Collapsed">
-                    <Grid Name="MainDetailScroll" Margin="10,0,10,0">
+            </StackPanel>
+
+            <Grid Grid.Row="1" Grid.Column="0">
+                <Grid Name="ServicesPanel" d:Visibility="Collapsed">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Grid Name="MainDetailScroll" Grid.Row="0" Margin="10,0,10,0">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="95*"/>
                             <ColumnDefinition Width="34*"/>
@@ -239,8 +248,8 @@
                             </ListView.ItemTemplate>
                         </ListView>
                     </Grid>
-                    <Label x:Name="ServiceCount" HorizontalAlignment="Center" Content="0 Services" Margin="0,0,0,0" Foreground="Gray" FontWeight="Bold" FontSize="12" FontFamily="pack://application:,,,/Assets/Fonts/#Open Sans"></Label>
-                </StackPanel>
+                    <Label x:Name="ServiceCount" Grid.Row="1" HorizontalAlignment="Center" Content="0 Services" Margin="0,0,0,0" Foreground="Gray" FontWeight="Bold" FontSize="12" FontFamily="pack://application:,,,/Assets/Fonts/#Open Sans"></Label>
+                </Grid>
                 <StackPanel Name="ExternalProviderPanel" Visibility="Visible">
                     <Grid MaxHeight="160" Margin="10,0,10,0">
                         <Grid.ColumnDefinitions>
@@ -384,8 +393,8 @@
                                Foreground="#FFFFFF"></Label>
                     </Grid>
                 </StackPanel>
-            </StackPanel>
-            <local:StyledButton x:Name="ForgetIdentityButton" Grid.Row="1"
+            </Grid>
+            <local:StyledButton x:Name="ForgetIdentityButton" Grid.Row="2"
                                 MinWidth="310"
                                 BgColor="#F4044D"
                                 Label="Forget This Identity"

--- a/DesktopEdge/Views/Screens/IdentityDetails.xaml.cs
+++ b/DesktopEdge/Views/Screens/IdentityDetails.xaml.cs
@@ -30,6 +30,7 @@ using System.Windows.Data;
 using System.Diagnostics.Eventing.Reader;
 using System.ComponentModel.Design.Serialization;
 using System.Security.Cryptography;
+using System.Windows.Threading;
 using ZitiDesktopEdge.ViewModels;
 
 namespace ZitiDesktopEdge {
@@ -95,14 +96,48 @@ namespace ZitiDesktopEdge {
                 IdentityDetailsViewModel.Identity = _identity;
                 IdentityDetailsViewModel.LoadServices();
                 ServiceCount.Content = IdentityDetailsViewModel.ServiceCountLabel;
-                double newHeight = MainHeight - 300;
-                MainDetailScroll.MaxHeight = newHeight;
-                MainDetailScroll.Height = newHeight;
+                // set once, MatchMainViewHeight corrects it
+                if (double.IsNaN(MainDetailScroll.Height)) {
+                    MainDetailScroll.Height = MainHeight - 300;
+                }
                 UpdateView();
+                if (!IsVisible) {
+                    // measure while still hidden so the first open comes up at the right size
+                    FrameworkElement root = (FrameworkElement)Content;
+                    root.Measure(new Size(MaxWidth, double.PositiveInfinity));
+                    MatchMainViewHeight(root.DesiredSize.Height);
+                }
                 IdentityArea.Opacity = 1.0;
                 IdentityArea.Visibility = Visibility.Visible;
                 this.Visibility = Visibility.Visible;
+                Dispatcher.BeginInvoke(new Action(MatchMainViewHeight), DispatcherPriority.Loaded);
             }
+        }
+
+        // resize the service list until this page is the same height as the main view,
+        // otherwise it docks closer to the taskbar. Must run after render.
+        private void MatchMainViewHeight() {
+            if (!IsVisible) {
+                return;
+            }
+            MatchMainViewHeight(IdentityArea.DesiredSize.Height);
+        }
+
+        private void MatchMainViewHeight(double pageHeight) {
+            if (MainDetailScroll.Visibility != Visibility.Visible) {
+                return;
+            }
+            // MainView's margins net to -10
+            double targetHeight = MainHeight - 10;
+            double delta = targetHeight - pageHeight;
+            if (Math.Abs(delta) < 0.5) {
+                return;
+            }
+            double fitted = MainDetailScroll.Height + delta;
+            if (fitted < 60) {
+                fitted = 60;
+            }
+            MainDetailScroll.Height = fitted;
         }
 
         public IdentityItem SelectedIdentity { get; set; }
@@ -631,6 +666,7 @@ namespace ZitiDesktopEdge {
                 ExternalProviderPanel.Visibility = Visibility.Collapsed;
                 ServicesPanel.Visibility = Visibility.Visible;
                 ExternalProviderStatusAndDetails.ToolTip = "Click to configure external auth providers";
+                Dispatcher.BeginInvoke(new Action(MatchMainViewHeight), DispatcherPriority.Loaded);
             } else {
                 //hide all panels, show the provider panel
                 ExternalProviderPanel.Visibility = Visibility.Visible;

--- a/DesktopEdge/Views/Screens/IdentityDetails.xaml.cs
+++ b/DesktopEdge/Views/Screens/IdentityDetails.xaml.cs
@@ -30,7 +30,6 @@ using System.Windows.Data;
 using System.Diagnostics.Eventing.Reader;
 using System.ComponentModel.Design.Serialization;
 using System.Security.Cryptography;
-using System.Windows.Threading;
 using ZitiDesktopEdge.ViewModels;
 
 namespace ZitiDesktopEdge {
@@ -70,7 +69,6 @@ namespace ZitiDesktopEdge {
         public event CommonDelegates.ShowBlurb ShowBlurb;
 
         private System.Windows.Forms.Timer _timer;
-        public double MainHeight = 500;
         private ScrollViewer _scroller;
         private ZitiService _info;
 
@@ -96,48 +94,11 @@ namespace ZitiDesktopEdge {
                 IdentityDetailsViewModel.Identity = _identity;
                 IdentityDetailsViewModel.LoadServices();
                 ServiceCount.Content = IdentityDetailsViewModel.ServiceCountLabel;
-                // set once, MatchMainViewHeight corrects it
-                if (double.IsNaN(MainDetailScroll.Height)) {
-                    MainDetailScroll.Height = MainHeight - 300;
-                }
                 UpdateView();
-                if (!IsVisible) {
-                    // measure while still hidden so the first open comes up at the right size
-                    FrameworkElement root = (FrameworkElement)Content;
-                    root.Measure(new Size(MaxWidth, double.PositiveInfinity));
-                    MatchMainViewHeight(root.DesiredSize.Height);
-                }
                 IdentityArea.Opacity = 1.0;
                 IdentityArea.Visibility = Visibility.Visible;
                 this.Visibility = Visibility.Visible;
-                Dispatcher.BeginInvoke(new Action(MatchMainViewHeight), DispatcherPriority.Loaded);
             }
-        }
-
-        // resize the service list until this page is the same height as the main view,
-        // otherwise it docks closer to the taskbar. Must run after render.
-        private void MatchMainViewHeight() {
-            if (!IsVisible) {
-                return;
-            }
-            MatchMainViewHeight(IdentityArea.DesiredSize.Height);
-        }
-
-        private void MatchMainViewHeight(double pageHeight) {
-            if (MainDetailScroll.Visibility != Visibility.Visible) {
-                return;
-            }
-            // MainView's margins net to -10
-            double targetHeight = MainHeight - 10;
-            double delta = targetHeight - pageHeight;
-            if (Math.Abs(delta) < 0.5) {
-                return;
-            }
-            double fitted = MainDetailScroll.Height + delta;
-            if (fitted < 60) {
-                fitted = 60;
-            }
-            MainDetailScroll.Height = fitted;
         }
 
         public IdentityItem SelectedIdentity { get; set; }
@@ -412,10 +373,6 @@ namespace ZitiDesktopEdge {
             this.Visibility = Visibility.Collapsed;
         }
 
-        public void SetHeight(double height) {
-            MainDetailScroll.Height = height;
-        }
-
         private void ForgetIdentity(object sender, MouseButtonEventArgs e) {
             if (this.Visibility == Visibility.Visible && ForgetIdentityConfirmView.Visibility == Visibility.Collapsed) {
                 ForgetIdentityConfirmView.Visibility = Visibility.Visible;
@@ -666,7 +623,6 @@ namespace ZitiDesktopEdge {
                 ExternalProviderPanel.Visibility = Visibility.Collapsed;
                 ServicesPanel.Visibility = Visibility.Visible;
                 ExternalProviderStatusAndDetails.ToolTip = "Click to configure external auth providers";
-                Dispatcher.BeginInvoke(new Action(MatchMainViewHeight), DispatcherPriority.Loaded);
             } else {
                 //hide all panels, show the provider panel
                 ExternalProviderPanel.Visibility = Visibility.Visible;

--- a/DesktopEdge/Views/Screens/MFAScreen.xaml
+++ b/DesktopEdge/Views/Screens/MFAScreen.xaml
@@ -22,7 +22,7 @@
              mc:Ignorable="d"
              d:DesignHeight="570"
              d:DesignWidth="420">
-    <Grid x:Name="MFAArea" Visibility="Visible" Margin="0,0,0,0">
+    <Grid x:Name="MFAArea" Visibility="Visible" Margin="0,0,0,0" VerticalAlignment="Center">
         <Border Margin="10,10,10,10" BorderBrush="Black" BorderThickness="8" CornerRadius="10">
             <Border.Effect>
                 <DropShadowEffect BlurRadius="20" Direction="1" RenderingBias="Quality" ShadowDepth="1" Opacity="1"/>

--- a/DesktopEdge/Views/Screens/MFAScreen.xaml.cs
+++ b/DesktopEdge/Views/Screens/MFAScreen.xaml.cs
@@ -233,9 +233,9 @@ namespace ZitiDesktopEdge {
 
             DataClient serviceClient = serviceClient = (DataClient)Application.Current.Properties["ServiceClient"];
             SvcResponse resp = await serviceClient.VerifyMFA(this.zid.Identifier, code);
+            // only close on failure. on success the enrollment_verification event swaps this
+            // screen over to the recovery codes, closing here too would race and dismiss them
             if (resp.Code != 0) {
-                this.OnClose?.Invoke(false, this);
-            } else {
                 this.OnClose?.Invoke(false, this);
             }
         }

--- a/DesktopEdge/Views/Screens/MFAScreen.xaml.cs
+++ b/DesktopEdge/Views/Screens/MFAScreen.xaml.cs
@@ -112,7 +112,8 @@ namespace ZitiDesktopEdge {
             SecretCode.Text = secret;
 
             _url = url;
-            MFAArea.Height = 515;
+            // 510 + the 30px show margins = 570, MainView's minimum. Taller grows the window.
+            MFAArea.Height = 510;
             MFAAuthArea.Visibility = Visibility.Collapsed;
             MFASetupArea.Visibility = Visibility.Visible;
             MFARecoveryArea.Visibility = Visibility.Collapsed;

--- a/DesktopEdge/Views/Screens/MFAScreen.xaml.cs
+++ b/DesktopEdge/Views/Screens/MFAScreen.xaml.cs
@@ -112,8 +112,6 @@ namespace ZitiDesktopEdge {
             SecretCode.Text = secret;
 
             _url = url;
-            // 510 + the 30px show margins = 570, MainView's minimum. Taller grows the window.
-            MFAArea.Height = 510;
             MFAAuthArea.Visibility = Visibility.Collapsed;
             MFASetupArea.Visibility = Visibility.Visible;
             MFARecoveryArea.Visibility = Visibility.Collapsed;
@@ -133,7 +131,6 @@ namespace ZitiDesktopEdge {
             MainBrush.Visibility = Visibility.Visible;
             CloseBlack.Visibility = Visibility.Visible;
             CloseWhite.Visibility = Visibility.Collapsed;
-            MFAArea.Height = 380;
             if (codes.Length > 0) {
                 for (int i = 0; i < codes.Length; i++) {
                     TextBox label = new TextBox();
@@ -172,7 +169,6 @@ namespace ZitiDesktopEdge {
                 MFARecoveryArea.Visibility = Visibility.Collapsed;
                 SeperationColor.Visibility = Visibility.Collapsed;
                 MFAAuthArea.Visibility = Visibility.Visible;
-                MFAArea.Height = 220;
                 AuthCode.Focusable = true;
                 AuthCode.Focus();
             } else {

--- a/DesktopEdge/Views/Screens/MainMenu.xaml.cs
+++ b/DesktopEdge/Views/Screens/MainMenu.xaml.cs
@@ -67,7 +67,6 @@ namespace ZitiDesktopEdge {
         private bool _suppressPolicyVmReRender = false;
         public string LogLevel = "";
         private string appVersion = null;
-        public double MainHeight = 500;
 
         private ZDEWViewState state;
         private ManagedSettingsViewModel policyViewModel;

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,3 +1,14 @@
+# Release 2.11.2.7
+## What's New
+n/a
+
+## Bugs fixed
+* [Issue 1020](https://github.com/openziti/desktop-edge-win/issues/1020) - Identity events no longer resize the identity details view
+* [Issue 1033](https://github.com/openziti/desktop-edge-win/issues/1033) - MFA recovery codes no longer disappear immediately after entering the setup code
+
+## Other changes
+n/a
+
 # Release 2.11.2.6
 ## What's New
 * updated to ziti-edge-tunnel v1.18.1


### PR DESCRIPTION
- Makes the identity details and MFA screen sizing layout-driven so identity events no longer resize the details view + cuts down on manual code behind dimension calculations.
- Stops the MFA recovery codes screen from closing before it can be read (intermittently).
- Shifted the main UI 10px closer to the task-bar (we removed the small arrow that used to point to the sys-tray icon a while back so this felt like dead space)

Closes #1020
Closes #1033