### PR TITLE
Allow switching back to default when an alternate ZET is gone

### DIFF
--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -604,13 +604,13 @@ namespace ZitiDesktopEdge {
 
         private async Task OpenTunnelInstancePickerAsync() {
             try {
-                var instances = await TunnelInstanceDiscovery.EnumerateAsync();
-                // Fire whenever a non-default tunneler exists, regardless of count. Covers the
-                // "only the alternate is running" case where there's still a meaningful switch
-                // (back to default). The picker synthesizes the default row when needed.
-                bool hasNonDefault = instances.Any(i => !string.IsNullOrEmpty(i.Discriminator));
-                if (!hasNonDefault) {
-                    logger.Debug("Ctrl+Shift+T ignored — no non-default tunneler instances ({0} total)", instances.Count);
+                IReadOnlyList<TunnelInstanceDiscovery.TunnelInstance> instances = await TunnelInstanceDiscovery.EnumerateAsync();
+                // Count what the picker will actually show, not what's running: the instance
+                // we're viewing stays on the list after its tunneler stops, and switching back
+                // to default is the only way off it.
+                IReadOnlyList<TunnelInstanceDiscovery.TunnelInstance> options = TunnelInstanceDiscovery.SwitchOptions(instances, serviceClient?.Discriminator);
+                if (options.Count <= 1) {
+                    logger.Debug("Ctrl+Shift+T ignored — nothing to switch to ({0} instances running)", instances.Count);
                     return;
                 }
             } catch (Exception ex) {

--- a/DesktopEdge/Tray/TrayMenuController.cs
+++ b/DesktopEdge/Tray/TrayMenuController.cs
@@ -429,15 +429,6 @@ namespace ZitiDesktopEdge.Tray {
                 return;
             }
 
-            // Same ordering as the picker window: default first (synthetic if not actually
-            // online), then everything else in discovery order.
-            var ordered = new List<TunnelInstanceDiscovery.TunnelInstance>();
-            var def = discovered.FirstOrDefault(i => string.IsNullOrEmpty(i.Discriminator));
-            ordered.Add(def ?? TunnelInstanceDiscovery.OfflineDefault());
-            foreach (var inst in discovered) {
-                if (!string.IsNullOrEmpty(inst.Discriminator)) ordered.Add(inst);
-            }
-
             dispatcher.Invoke(() => {
                 // Tear down previous items. ToolStripItem.Dispose() removes the item from its
                 // owner's collection, so iterating DropDownItems while disposing skips every
@@ -450,14 +441,16 @@ namespace ZitiDesktopEdge.Tray {
                     oldItem.Dispose();
                 }
 
+                DataClient serviceClient = Application.Current.Properties["ServiceClient"] as DataClient;
+                string activeDisc = serviceClient?.Discriminator ?? "";
+                IReadOnlyList<TunnelInstanceDiscovery.TunnelInstance> ordered = TunnelInstanceDiscovery.SwitchOptions(discovered, activeDisc);
+
                 if (ordered.Count <= 1) {
                     trayTunnelerSubmenu.Visible = false;
                     return;
                 }
 
-                var serviceClient = Application.Current.Properties["ServiceClient"] as DataClient;
-                string activeDisc = serviceClient?.Discriminator ?? "";
-                foreach (var inst in ordered) {
+                foreach (TunnelInstanceDiscovery.TunnelInstance inst in ordered) {
                     string instDisc = inst.Discriminator ?? "";
                     bool isActive = string.Equals(instDisc, activeDisc, StringComparison.Ordinal) && inst.IsOnline;
                     string suffix = isActive ? "   (active)" : (!inst.IsOnline ? "   (not running)" : "");

--- a/DesktopEdge/TunnelInstancePickerWindow.cs
+++ b/DesktopEdge/TunnelInstancePickerWindow.cs
@@ -96,15 +96,7 @@ namespace ZitiDesktopEdge {
                 return;
             }
 
-            // Assemble the display list: default is always first, synthetic if
-            // it's not actually running. Everything else follows in the order
-            // discovery returned them.
-            var ordered = new List<TunnelInstanceDiscovery.TunnelInstance>();
-            var def = discovered.FirstOrDefault(i => string.IsNullOrEmpty(i.Discriminator));
-            ordered.Add(def ?? TunnelInstanceDiscovery.OfflineDefault());
-            foreach (var inst in discovered) {
-                if (!string.IsNullOrEmpty(inst.Discriminator)) ordered.Add(inst);
-            }
+            IReadOnlyList<TunnelInstanceDiscovery.TunnelInstance> ordered = TunnelInstanceDiscovery.SwitchOptions(discovered, activeDiscriminator);
 
             int liveCount = ordered.Count(i => i.IsOnline);
             statusLabel.Text = liveCount == 0

--- a/ZitiDesktopEdge.Client/ServiceClient/TunnelInstanceDiscovery.cs
+++ b/ZitiDesktopEdge.Client/ServiceClient/TunnelInstanceDiscovery.cs
@@ -67,18 +67,36 @@ namespace ZitiDesktopEdge.ServiceClient {
         }
 
         /// <summary>
-        /// Construct a synthetic "default" TunnelInstance marked as offline.
-        /// Used by the picker so the default row is always visible even when
-        /// the default ziti-edge-tunnel isn't running — letting the user
-        /// come back to it after starting the service.
+        /// A TunnelInstance for a pipe nothing is listening on, so the UI can still offer it.
         /// </summary>
-        public static TunnelInstance OfflineDefault() {
+        public static TunnelInstance Offline(string discriminator) {
+            string disc = string.IsNullOrEmpty(discriminator) ? null : discriminator;
             return new TunnelInstance {
-                Discriminator = null,
-                PipeName = "ziti-edge-tunnel.sock",
-                EventPipeName = "ziti-edge-tunnel-event.sock",
+                Discriminator = disc,
+                PipeName = disc == null ? DefaultPipeName : DefaultPipeName + "." + disc,
+                EventPipeName = disc == null ? DefaultEventPipeName : DefaultEventPipeName + "." + disc,
                 IsOnline = false,
             };
+        }
+
+        /// <summary>
+        /// The instances to offer for switching: default first, then discovered alternates.
+        /// The active instance is always present, so a stopped alternate stays selectable
+        /// until the user switches off it instead of stranding them on it.
+        /// </summary>
+        public static IReadOnlyList<TunnelInstance> SwitchOptions(IReadOnlyList<TunnelInstance> discovered, string activeDiscriminator) {
+            List<TunnelInstance> ordered = new List<TunnelInstance>();
+            TunnelInstance def = discovered.FirstOrDefault(i => string.IsNullOrEmpty(i.Discriminator));
+            ordered.Add(def ?? Offline(null));
+            foreach (TunnelInstance inst in discovered) {
+                if (!string.IsNullOrEmpty(inst.Discriminator)) ordered.Add(inst);
+            }
+
+            string active = string.IsNullOrEmpty(activeDiscriminator) ? null : activeDiscriminator;
+            if (active != null && !ordered.Any(i => string.Equals(i.Discriminator, active, StringComparison.Ordinal))) {
+                ordered.Add(Offline(active));
+            }
+            return ordered;
         }
 
         /// <summary>

--- a/ZitiDesktopEdge.Client/ServiceClient/TunnelInstanceDiscovery.cs
+++ b/ZitiDesktopEdge.Client/ServiceClient/TunnelInstanceDiscovery.cs
@@ -80,23 +80,19 @@ namespace ZitiDesktopEdge.ServiceClient {
         }
 
         /// <summary>
-        /// The instances to offer for switching: default first, then discovered alternates.
-        /// The active instance is always present, so a stopped alternate stays selectable
-        /// until the user switches off it instead of stranding them on it.
+        /// Default first, then discovered alternates. The active instance is always included so a
+        /// stopped one stays selectable until the user switches off it.
         /// </summary>
         public static IReadOnlyList<TunnelInstance> SwitchOptions(IReadOnlyList<TunnelInstance> discovered, string activeDiscriminator) {
-            List<TunnelInstance> ordered = new List<TunnelInstance>();
-            TunnelInstance def = discovered.FirstOrDefault(i => string.IsNullOrEmpty(i.Discriminator));
-            ordered.Add(def ?? Offline(null));
+            List<TunnelInstance> options = new List<TunnelInstance>();
+            options.Add(discovered.FirstOrDefault(i => string.IsNullOrEmpty(i.Discriminator)) ?? Offline(null));
             foreach (TunnelInstance inst in discovered) {
-                if (!string.IsNullOrEmpty(inst.Discriminator)) ordered.Add(inst);
+                if (!string.IsNullOrEmpty(inst.Discriminator)) options.Add(inst);
             }
-
-            string active = string.IsNullOrEmpty(activeDiscriminator) ? null : activeDiscriminator;
-            if (active != null && !ordered.Any(i => string.Equals(i.Discriminator, active, StringComparison.Ordinal))) {
-                ordered.Add(Offline(active));
+            if (!string.IsNullOrEmpty(activeDiscriminator) && !options.Any(i => i.Discriminator == activeDiscriminator)) {
+                options.Add(Offline(activeDiscriminator));
             }
-            return ordered;
+            return options;
         }
 
         /// <summary>


### PR DESCRIPTION
Switching to a `-P whatever` tunneler and then eventually stopping it stranded the UI on a dead pipe.
- The instance you're viewing now stays in the switch list until you pick something else, and both `Ctrl+Shift+T` and the tray's Switch Tunneler submenu count what's actually shown instead of what's running.