### PR TITLE
Restore monitor service settings from Windows.old after a Windows upgrade

### DIFF
--- a/ZitiUpdateService.Tests/WindowsUpgradeBackupTests.cs
+++ b/ZitiUpdateService.Tests/WindowsUpgradeBackupTests.cs
@@ -97,6 +97,17 @@ namespace ZitiUpdateService.Tests {
         }
 
         [TestMethod]
+        public void EmptyBackupFile_RejectedAndLeftInPlace() {
+            Directory.CreateDirectory(oldFolder);
+            File.WriteAllText(Path.Combine(oldFolder, "settings.json"), string.Empty);
+
+            WindowsUpgradeBackup.RestoreMissingFiles(liveFolder, new string[] { oldFolder, btFolder });
+
+            Assert.IsFalse(File.Exists(Path.Combine(liveFolder, "settings.json")), "empty backup must not be restored");
+            Assert.IsTrue(File.Exists(Path.Combine(oldFolder, "settings.json")), "rejected backup must not be deleted");
+        }
+
+        [TestMethod]
         public void NoBackupFolders_LeavesLiveFolderUntouched() {
             WindowsUpgradeBackup.RestoreMissingFiles(liveFolder, new string[] { oldFolder, btFolder });
 

--- a/ZitiUpdateService.Tests/WindowsUpgradeBackupTests.cs
+++ b/ZitiUpdateService.Tests/WindowsUpgradeBackupTests.cs
@@ -12,11 +12,7 @@ using ZitiUpdateService.Utils;
 
 namespace ZitiUpdateService.Tests {
     /// <summary>
-    /// Tests for the Windows-upgrade settings recovery (issue #1050). A Windows upgrade moves
-    /// the SYSTEM profile to Windows.old and the monitor service regenerates default settings
-    /// before ziti-edge-tunnel's own recovery runs, so the service restores its own folder.
-    /// Semantics mirror ziti-edge-tunnel's move_config_from_previous_windows_backup: an
-    /// existing live file wins, and a backup file is only deleted after a successful restore.
+    /// Ensure settings are restored after a Windows upgrade (issue #1050). Rationale is on <see cref="WindowsUpgradeBackup"/>.
     /// </summary>
     [TestClass]
     public class WindowsUpgradeBackupTests {

--- a/ZitiUpdateService.Tests/WindowsUpgradeBackupTests.cs
+++ b/ZitiUpdateService.Tests/WindowsUpgradeBackupTests.cs
@@ -1,0 +1,110 @@
+/*
+    Copyright NetFoundry Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+*/
+
+using ZitiUpdateService.Utils;
+
+namespace ZitiUpdateService.Tests {
+    /// <summary>
+    /// Tests for the Windows-upgrade settings recovery (issue #1050). A Windows upgrade moves
+    /// the SYSTEM profile to Windows.old and the monitor service regenerates default settings
+    /// before ziti-edge-tunnel's own recovery runs, so the service restores its own folder.
+    /// Semantics mirror ziti-edge-tunnel's move_config_from_previous_windows_backup: an
+    /// existing live file wins, and a backup file is only deleted after a successful restore.
+    /// </summary>
+    [TestClass]
+    public class WindowsUpgradeBackupTests {
+
+        private const string ModifiedSettingsJson = @"{
+  ""AutomaticUpdatesDisabled"": false,
+  ""AutomaticUpdateURL"": ""https://get.openziti.io/zdew/stable.json"",
+  ""AlivenessChecksBeforeAction"": 12,
+  ""DeferInstallToRestart"": false,
+  ""MaintenanceWindowStart"": 0,
+  ""MaintenanceWindowEnd"": 8,
+  ""MaintenanceWindowFrequency"": 1,
+  ""MaintenanceWindowDayOfWeek"": 2,
+  ""MaintenanceWindowDayOfMonth"": null,
+  ""MaintenanceWindowMonthlyMode"": 0,
+  ""MaintenanceWindowMonthlyOrdinal"": null
+}";
+
+        private const string DefaultSettingsJson = @"{
+  ""AutomaticUpdatesDisabled"": false,
+  ""AutomaticUpdateURL"": ""https://get.openziti.io/zdew/stable.json"",
+  ""AlivenessChecksBeforeAction"": 12,
+  ""DeferInstallToRestart"": false,
+  ""MaintenanceWindowStart"": 0,
+  ""MaintenanceWindowEnd"": 0,
+  ""MaintenanceWindowFrequency"": 0,
+  ""MaintenanceWindowDayOfWeek"": null,
+  ""MaintenanceWindowDayOfMonth"": null,
+  ""MaintenanceWindowMonthlyMode"": 0,
+  ""MaintenanceWindowMonthlyOrdinal"": null
+}";
+
+        private string root = null!;
+        private string liveFolder = null!;
+        private string oldFolder = null!;
+        private string btFolder = null!;
+
+        [TestInitialize]
+        public void CreateFolders() {
+            root = Path.Combine(Path.GetTempPath(), "zdew-upgrade-" + Guid.NewGuid().ToString("N"));
+            liveFolder = Path.Combine(root, "live");
+            oldFolder = Path.Combine(root, "Windows.old");
+            btFolder = Path.Combine(root, "$Windows.~BT");
+            Directory.CreateDirectory(liveFolder);
+        }
+
+        [TestCleanup]
+        public void RemoveFolders() {
+            Directory.Delete(root, true);
+        }
+
+        [TestMethod]
+        public void MissingFile_RestoredFromBackupAndBackupRemoved() {
+            Directory.CreateDirectory(oldFolder);
+            File.WriteAllText(Path.Combine(oldFolder, "settings.json"), ModifiedSettingsJson);
+
+            WindowsUpgradeBackup.RestoreMissingFiles(liveFolder, new string[] { oldFolder, btFolder });
+
+            Assert.AreEqual(ModifiedSettingsJson, File.ReadAllText(Path.Combine(liveFolder, "settings.json")));
+            Assert.IsFalse(Directory.Exists(oldFolder), "emptied backup folder should be removed");
+        }
+
+        [TestMethod]
+        public void ExistingFile_WinsAndBackupLeftInPlace() {
+            File.WriteAllText(Path.Combine(liveFolder, "settings.json"), DefaultSettingsJson);
+            Directory.CreateDirectory(oldFolder);
+            File.WriteAllText(Path.Combine(oldFolder, "settings.json"), ModifiedSettingsJson);
+
+            WindowsUpgradeBackup.RestoreMissingFiles(liveFolder, new string[] { oldFolder, btFolder });
+
+            Assert.AreEqual(DefaultSettingsJson, File.ReadAllText(Path.Combine(liveFolder, "settings.json")));
+            Assert.IsTrue(File.Exists(Path.Combine(oldFolder, "settings.json")), "unrestored backup must not be deleted");
+        }
+
+        [TestMethod]
+        public void EmptyBackupFolder_Removed() {
+            Directory.CreateDirectory(oldFolder);
+
+            WindowsUpgradeBackup.RestoreMissingFiles(liveFolder, new string[] { oldFolder, btFolder });
+
+            Assert.IsFalse(Directory.Exists(oldFolder));
+        }
+
+        [TestMethod]
+        public void NoBackupFolders_LeavesLiveFolderUntouched() {
+            WindowsUpgradeBackup.RestoreMissingFiles(liveFolder, new string[] { oldFolder, btFolder });
+
+            Assert.AreEqual(0, Directory.GetFileSystemEntries(liveFolder).Length);
+        }
+    }
+}

--- a/ZitiUpdateService/ZitiUpdateService.csproj
+++ b/ZitiUpdateService/ZitiUpdateService.csproj
@@ -193,6 +193,7 @@
     <Compile Include="utils\Settings.cs" />
     <Compile Include="utils\MaintenanceWindowEvaluator.cs" />
     <Compile Include="utils\InstallationCriticalEvaluator.cs" />
+    <Compile Include="utils\WindowsUpgradeBackup.cs" />
     <Compile Include="UpdateService.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/ZitiUpdateService/utils/Settings.cs
+++ b/ZitiUpdateService/utils/Settings.cs
@@ -67,6 +67,7 @@ namespace ZitiUpdateService.Utils {
             string file = "settings.json";
             Location = Path.Combine(folder, file);
             Directory.CreateDirectory(folder);
+            WindowsUpgradeBackup.RestoreMissingFiles(folder, WindowsUpgradeBackup.BackupFolders(folder));
             watcher = new FileSystemWatcher(folder);
             watcher.Filter = file;
 

--- a/ZitiUpdateService/utils/WindowsUpgradeBackup.cs
+++ b/ZitiUpdateService/utils/WindowsUpgradeBackup.cs
@@ -1,0 +1,72 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+using System;
+using System.IO;
+using NLog;
+
+namespace ZitiUpdateService.Utils {
+    // A Windows upgrade moves the SYSTEM profile into a backup folder. ziti-edge-tunnel only
+    // recovers its own files, and this service regenerates default settings at startup before
+    // ziti-edge-tunnel even runs, so this service restores its own folder before Load()/Write().
+    public static class WindowsUpgradeBackup {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+        public static string[] BackupFolders(string folder) {
+            string root = Path.GetPathRoot(folder);
+            string relativePath = folder.Substring(root.Length);
+            return new string[] {
+                Path.Combine(root, "Windows.old", relativePath),
+                Path.Combine(root, "$Windows.~BT", relativePath)
+            };
+        }
+
+        public static void RestoreMissingFiles(string folder, string[] backupFolders) {
+            foreach (string backupFolder in backupFolders) {
+                if (!Directory.Exists(backupFolder)) {
+                    continue;
+                }
+                foreach (string backupFile in Directory.GetFiles(backupFolder)) {
+                    string liveFile = Path.Combine(folder, Path.GetFileName(backupFile));
+                    if (File.Exists(liveFile)) {
+                        // never delete a backup that was not restored, Windows prunes Windows.old on its own
+                        Logger.Warn("keeping existing file {0}, backup file left at {1}", liveFile, backupFile);
+                        continue;
+                    }
+                    try {
+                        File.Copy(backupFile, liveFile);
+                        Logger.Info("restored {0} from the Windows upgrade backup at {1}", liveFile, backupFile);
+                    } catch (Exception ex) {
+                        Logger.Error("failed to copy backup file {0}: {1}", backupFile, ex.Message);
+                        continue;
+                    }
+                    try {
+                        File.Delete(backupFile);
+                    } catch (Exception ex) {
+                        Logger.Warn("failed to remove backup file {0}: {1}", backupFile, ex.Message);
+                    }
+                }
+                if (Directory.GetFileSystemEntries(backupFolder).Length == 0) {
+                    try {
+                        Directory.Delete(backupFolder);
+                    } catch (Exception ex) {
+                        Logger.Warn("failed to remove empty backup folder {0}: {1}", backupFolder, ex.Message);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ZitiUpdateService/utils/WindowsUpgradeBackup.cs
+++ b/ZitiUpdateService/utils/WindowsUpgradeBackup.cs
@@ -24,45 +24,61 @@ namespace ZitiUpdateService.Utils {
     public static class WindowsUpgradeBackup {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public static string[] BackupFolders(string folder) {
-            string root = Path.GetPathRoot(folder);
-            string relativePath = folder.Substring(root.Length);
+        // Where Windows Setup backs up 'destination': the system drive's Windows.old plus the drive-relative path.
+        public static string[] BackupFolders(string destination) {
+            string systemDrive = Path.GetPathRoot(Environment.GetFolderPath(Environment.SpecialFolder.Windows));
+            string relativePath = destination.Substring(Path.GetPathRoot(destination).Length);
             return new string[] {
-                Path.Combine(root, "Windows.old", relativePath),
-                Path.Combine(root, "$Windows.~BT", relativePath)
+                Path.Combine(systemDrive, "Windows.old", relativePath),
+                Path.Combine(systemDrive, "$Windows.~BT", relativePath)
             };
         }
 
-        public static void RestoreMissingFiles(string folder, string[] backupFolders) {
+        // Copies backup files into 'destination', skipping any file that already exists there and empty backups.
+        // A backup file is deleted only after a successful copy, its folder only once empty.
+        public static void RestoreMissingFiles(string destination, string[] backupFolders) {
             foreach (string backupFolder in backupFolders) {
-                if (!Directory.Exists(backupFolder)) {
+                try {
+                    RestoreFolder(destination, backupFolder);
+                } catch (Exception ex) {
+                    // Runs in a static initializer, an escaped exception would kill the service.
+                    Logger.Error(ex, "failed restoring backup files from {0}", backupFolder);
+                }
+            }
+        }
+
+        private static void RestoreFolder(string destination, string backupFolder) {
+            if (!Directory.Exists(backupFolder)) {
+                return;
+            }
+            foreach (string backupFile in Directory.GetFiles(backupFolder)) {
+                string liveFile = Path.Combine(destination, Path.GetFileName(backupFile));
+                if (File.Exists(liveFile)) {
+                    Logger.Warn("keeping existing file {0}, backup file left at {1}", liveFile, backupFile);
                     continue;
                 }
-                foreach (string backupFile in Directory.GetFiles(backupFolder)) {
-                    string liveFile = Path.Combine(folder, Path.GetFileName(backupFile));
-                    if (File.Exists(liveFile)) {
-                        Logger.Warn("keeping existing file {0}, backup file left at {1}", liveFile, backupFile);
-                        continue;
-                    }
-                    try {
-                        File.Copy(backupFile, liveFile);
-                        Logger.Info("restored {0} from the Windows upgrade backup at {1}", liveFile, backupFile);
-                    } catch (Exception ex) {
-                        Logger.Error("failed to copy backup file {0}: {1}", backupFile, ex.Message);
-                        continue;
-                    }
-                    try {
-                        File.Delete(backupFile);
-                    } catch (Exception ex) {
-                        Logger.Warn("failed to remove backup file {0}: {1}", backupFile, ex.Message);
-                    }
+                if (new FileInfo(backupFile).Length == 0) {
+                    Logger.Warn("ignoring empty backup file {0}", backupFile);
+                    continue;
                 }
-                if (Directory.GetFileSystemEntries(backupFolder).Length == 0) {
-                    try {
-                        Directory.Delete(backupFolder);
-                    } catch (Exception ex) {
-                        Logger.Warn("failed to remove empty backup folder {0}: {1}", backupFolder, ex.Message);
-                    }
+                try {
+                    File.Copy(backupFile, liveFile);
+                    Logger.Info("restored {0} from the Windows upgrade backup at {1}", liveFile, backupFile);
+                } catch (Exception ex) {
+                    Logger.Error(ex, "failed to copy backup file {0}", backupFile);
+                    continue;
+                }
+                try {
+                    File.Delete(backupFile);
+                } catch (Exception ex) {
+                    Logger.Warn(ex, "failed to remove backup file {0}", backupFile);
+                }
+            }
+            if (Directory.GetFileSystemEntries(backupFolder).Length == 0) {
+                try {
+                    Directory.Delete(backupFolder);
+                } catch (Exception ex) {
+                    Logger.Warn(ex, "failed to remove empty backup folder {0}", backupFolder);
                 }
             }
         }

--- a/ZitiUpdateService/utils/WindowsUpgradeBackup.cs
+++ b/ZitiUpdateService/utils/WindowsUpgradeBackup.cs
@@ -19,9 +19,8 @@ using System.IO;
 using NLog;
 
 namespace ZitiUpdateService.Utils {
-    // A Windows upgrade moves the SYSTEM profile into a backup folder. ziti-edge-tunnel only
-    // recovers its own files, and this service regenerates default settings at startup before
-    // ziti-edge-tunnel even runs, so this service restores its own folder before Load()/Write().
+    // A Windows upgrade can move the SYSTEM profile into a backup folder.
+    // Restore settings from the backup folder so defaults aren't written when the service starts.
     public static class WindowsUpgradeBackup {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
@@ -42,7 +41,6 @@ namespace ZitiUpdateService.Utils {
                 foreach (string backupFile in Directory.GetFiles(backupFolder)) {
                     string liveFile = Path.Combine(folder, Path.GetFileName(backupFile));
                     if (File.Exists(liveFile)) {
-                        // never delete a backup that was not restored, Windows prunes Windows.old on its own
                         Logger.Warn("keeping existing file {0}, backup file left at {1}", liveFile, backupFile);
                         continue;
                     }

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,3 +1,13 @@
+# Release 2.11.2.10
+## What's New
+n/a
+
+## Bugs fixed
+* [Issue 1050](https://github.com/openziti/desktop-edge-win/issues/1050) - Restore monitor service settings from Windows.old after a Windows upgrade
+
+## Other changes
+n/a
+
 # Release 2.11.2.9
 ## What's New
 * updated to ziti-edge-tunnel v1.18.4


### PR DESCRIPTION
- Restore monitor service settings from Windows.old before settings load and defaults are written
- Never overwrite an existing file with a backup copy, and only delete a backup file after a successful restore, otherwise it stays in Windows.old with a warning naming both paths
- Scan Windows.old first, then $Windows.~BT
- Add Windows upgrade restore tests
- Closes #1050 