### PR TITLE
Toast identities needing authorization once per condition, not per refresh

### DIFF
--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -238,8 +238,9 @@ namespace ZitiDesktopEdge {
                         _notificationThrottle.Remove(mfa.Identifier);
                     }
                 } else if (mfa.Action == "enrollment_required") {
+                    // no window pop here: ziti-edge-tunnel re-sends this event on every refresh
+                    // cycle while auth is pending. the queued toast is the user-facing prompt.
                     logger.Debug("MFA enrollment required for identity {0}", mfa.Identifier);
-                    BringWindowForward();
                 } else {
                     await ShowBlurbAsync("Unexpected error when processing MFA", "");
                     logger.Error("unexpected action: " + mfa.Action);
@@ -1697,7 +1698,7 @@ namespace ZitiDesktopEdge {
                         found.IsConnected = true;
                         found.NeedsExtAuth = e.Id.NeedsExtAuth;
                         found.ExtAuthProviders = e.Id.ExtAuthProviders;
-                        if (!found.NeedsExtAuth) {
+                        if (!found.NeedsExtAuth && !e.Id.MfaNeeded) {
                             _notificationThrottle.Remove(found.Identifier);
                         }
                         for (int i = 0; i < identities.Count; i++) {

--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -1699,7 +1699,7 @@ namespace ZitiDesktopEdge {
                         found.IsConnected = true;
                         found.NeedsExtAuth = e.Id.NeedsExtAuth;
                         found.ExtAuthProviders = e.Id.ExtAuthProviders;
-                        found.IsMFANeeded = e.Id.MfaNeeded;
+                        found.IsMFANeeded = zid.IsMFANeeded;
                         if (!found.NeedsExtAuth && !found.IsMFANeeded) {
                             _notificationThrottle.Remove(found.Identifier);
                         }

--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -188,6 +188,7 @@ namespace ZitiDesktopEdge {
                             }
                         }
                         if (this.IdentityMenu.Identity != null && this.IdentityMenu.Identity.Identifier == mfa.Identifier) this.IdentityMenu.Identity = found;
+                        _notificationThrottle.Remove(mfa.Identifier);
                         ShowMFARecoveryCodes(found);
                     } else {
                         await ShowBlurbAsync("Provided code could not be verified", "");

--- a/DesktopEdge/MainWindow.xaml.cs
+++ b/DesktopEdge/MainWindow.xaml.cs
@@ -212,6 +212,7 @@ namespace ZitiDesktopEdge {
                             }
                         }
                         if (this.IdentityMenu.Identity != null && this.IdentityMenu.Identity.Identifier == mfa.Identifier) this.IdentityMenu.Identity = found;
+                        _notificationThrottle.Remove(mfa.Identifier);
                         await ShowBlurbAsync("MFA disabled, access may be limited", "");
                     } else {
                         await ShowBlurbAsync("MFA Removal Failed", "");
@@ -1698,7 +1699,8 @@ namespace ZitiDesktopEdge {
                         found.IsConnected = true;
                         found.NeedsExtAuth = e.Id.NeedsExtAuth;
                         found.ExtAuthProviders = e.Id.ExtAuthProviders;
-                        if (!found.NeedsExtAuth && !e.Id.MfaNeeded) {
+                        found.IsMFANeeded = e.Id.MfaNeeded;
+                        if (!found.NeedsExtAuth && !found.IsMFANeeded) {
                             _notificationThrottle.Remove(found.Identifier);
                         }
                         for (int i = 0; i < identities.Count; i++) {
@@ -1880,6 +1882,7 @@ namespace ZitiDesktopEdge {
                 }
             }
             identities.Remove(idToRemove);
+            _notificationThrottle.Remove(forgotten.Identifier);
             LoadIdentities(false);
         }
 
@@ -1947,7 +1950,10 @@ namespace ZitiDesktopEdge {
                     updateViewWithIdentity(id);
                 }
                 foreach (var zid in identities) {
-                    if (!zid.IsEnabled) continue;
+                    if (!zid.IsEnabled) {
+                        _notificationThrottle.Remove(zid.Identifier);
+                        continue;
+                    }
                     if (zid.NeedsExtAuth) {
                         QueueExtAuthNotification(zid);
                     }

--- a/DesktopEdge/Utils/NotificationThrottle.cs
+++ b/DesktopEdge/Utils/NotificationThrottle.cs
@@ -72,6 +72,7 @@ namespace Ziti.Desktop.Edge.Utils {
         /// Removes a single identity from the seen set so it can trigger notifications again.
         /// </summary>
         public void Remove(string identityIdentifier) {
+            if (string.IsNullOrEmpty(identityIdentifier)) return;
             _pendingNotifications.Remove(identityIdentifier);
             _notified.Remove(identityIdentifier);
         }

--- a/DesktopEdge/Utils/NotificationThrottle.cs
+++ b/DesktopEdge/Utils/NotificationThrottle.cs
@@ -58,7 +58,7 @@ namespace Ziti.Desktop.Edge.Utils {
         public void Queue(string identityIdentifier, string message, ToastButton button) {
             // reached from the IPC reader thread via addService, where DispatcherTimer.Stop/Start throw on VerifyAccess
             if (!_dispatcher.CheckAccess()) {
-                _dispatcher.Invoke(() => Queue(identityIdentifier, message, button));
+                _dispatcher.BeginInvoke(new Action(() => Queue(identityIdentifier, message, button)));
                 return;
             }
             if (_notified.Contains(identityIdentifier)) return;

--- a/DesktopEdge/Utils/NotificationThrottle.cs
+++ b/DesktopEdge/Utils/NotificationThrottle.cs
@@ -32,6 +32,7 @@ namespace Ziti.Desktop.Edge.Utils {
         private readonly Dictionary<string, Action> _pendingNotifications = new Dictionary<string, Action>();
         private readonly HashSet<string> _notified = new HashSet<string>();
         private readonly DispatcherTimer _throttleTimer;
+        private readonly Dispatcher _dispatcher;
         private readonly string _header;
         private readonly string _summaryFormat;
 
@@ -45,6 +46,7 @@ namespace Ziti.Desktop.Edge.Utils {
             _sendNotification = sendNotification;
             _header = header;
             _summaryFormat = summaryFormat;
+            _dispatcher = Dispatcher.CurrentDispatcher;
             _throttleTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5) };
             _throttleTimer.Tick += (s, e) => SendPendingNotifications();
         }
@@ -54,6 +56,11 @@ namespace Ziti.Desktop.Edge.Utils {
         /// notified. Resets the 5-second window each time a new notification arrives.
         /// </summary>
         public void Queue(string identityIdentifier, string message, ToastButton button) {
+            // reached from the IPC reader thread via addService, where DispatcherTimer.Stop/Start throw on VerifyAccess
+            if (!_dispatcher.CheckAccess()) {
+                _dispatcher.Invoke(() => Queue(identityIdentifier, message, button));
+                return;
+            }
             if (_notified.Contains(identityIdentifier)) return;
             if (_pendingNotifications.ContainsKey(identityIdentifier)) return;
             _pendingNotifications[identityIdentifier] = () => _sendNotification(_header, message, button);

--- a/DesktopEdge/Utils/NotificationThrottle.cs
+++ b/DesktopEdge/Utils/NotificationThrottle.cs
@@ -30,6 +30,7 @@ namespace Ziti.Desktop.Edge.Utils {
 
         private readonly Action<string, string, ToastButton> _sendNotification;
         private readonly Dictionary<string, Action> _pendingNotifications = new Dictionary<string, Action>();
+        private readonly HashSet<string> _notified = new HashSet<string>();
         private readonly DispatcherTimer _throttleTimer;
         private readonly string _header;
         private readonly string _summaryFormat;
@@ -49,10 +50,11 @@ namespace Ziti.Desktop.Edge.Utils {
         }
 
         /// <summary>
-        /// Adds a notification to the pending queue. Skips duplicates for the same identity.
-        /// Resets the 5-second window each time a new notification arrives.
+        /// Adds a notification to the pending queue. Skips identities already pending or already
+        /// notified. Resets the 5-second window each time a new notification arrives.
         /// </summary>
         public void Queue(string identityIdentifier, string message, ToastButton button) {
+            if (_notified.Contains(identityIdentifier)) return;
             if (_pendingNotifications.ContainsKey(identityIdentifier)) return;
             _pendingNotifications[identityIdentifier] = () => _sendNotification(_header, message, button);
             _throttleTimer.Stop();
@@ -64,6 +66,7 @@ namespace Ziti.Desktop.Edge.Utils {
         /// </summary>
         public void Remove(string identityIdentifier) {
             _pendingNotifications.Remove(identityIdentifier);
+            _notified.Remove(identityIdentifier);
         }
 
         /// <summary>
@@ -72,6 +75,7 @@ namespace Ziti.Desktop.Edge.Utils {
         public void Clear() {
             _throttleTimer.Stop();
             _pendingNotifications.Clear();
+            _notified.Clear();
         }
 
         /// <summary>
@@ -94,6 +98,7 @@ namespace Ziti.Desktop.Edge.Utils {
                 // Send the single notification
                 _pendingNotifications.Values.First()();
             }
+            _notified.UnionWith(_pendingNotifications.Keys);
             _pendingNotifications.Clear();
         }
     }

--- a/release-notes.md
+++ b/release-notes.md
@@ -4,6 +4,8 @@ n/a
 
 ## Bugs fixed
 * [Issue 1050](https://github.com/openziti/desktop-edge-win/issues/1050) - Restore monitor service settings from Windows.old after a Windows upgrade
+* [Issue 1053](https://github.com/openziti/desktop-edge-win/issues/1053) - Toast identities needing authorization once instead of on every service refresh
+* The window no longer takes focus every time an identity reports that MFA enrollment is required
 
 ## Other changes
 n/a


### PR DESCRIPTION
- Fixes #1053
- Track which identities have already been notified, do not re-toast until the condition clears
- Clear throttle state on forget, disable, MFA removal, and successful auth
- Don't bring UI forward on enrollment_required