### PR TITLE
Preserve sort order and default ext-auth providers across upgrades

### DIFF
--- a/DesktopEdge/App.config
+++ b/DesktopEdge/App.config
@@ -32,6 +32,9 @@
             <setting name="SortDirection" serializeAs="String">
                 <value>Ascending</value>
             </setting>
+            <setting name="SettingsUpgradeRequired" serializeAs="String">
+                <value>True</value>
+            </setting>
         </ZitiDesktopEdge.Properties.Settings>
     </userSettings>
 </configuration>

--- a/DesktopEdge/App.xaml.cs
+++ b/DesktopEdge/App.xaml.cs
@@ -50,6 +50,13 @@ namespace ZitiDesktopEdge {
         protected override void OnStartup(StartupEventArgs e) {
             UpgradeSentinel.RemoveUpgradeSentinelExe();
             try {
+                // AssemblyVersion changes every release, moving user.config; carry prior settings forward
+                if (ZitiDesktopEdge.Properties.Settings.Default.SettingsUpgradeRequired) {
+                    ZitiDesktopEdge.Properties.Settings.Default.Upgrade();
+                    ZitiDesktopEdge.Properties.Settings.Default.SettingsUpgradeRequired = false;
+                    ZitiDesktopEdge.Properties.Settings.Default.Save();
+                }
+
                 Current.Properties["ZDEWViewState"] = new ZDEWViewState();
 
                 ManagedSettingsState policyState = ManagedSettingsReader.Read();

--- a/DesktopEdge/Properties/Settings.Designer.cs
+++ b/DesktopEdge/Properties/Settings.Designer.cs
@@ -57,5 +57,17 @@ namespace ZitiDesktopEdge.Properties {
                 this["SortDirection"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool SettingsUpgradeRequired {
+            get {
+                return ((bool)(this["SettingsUpgradeRequired"]));
+            }
+            set {
+                this["SettingsUpgradeRequired"] = value;
+            }
+        }
     }
 }

--- a/DesktopEdge/Properties/Settings.settings
+++ b/DesktopEdge/Properties/Settings.settings
@@ -11,5 +11,8 @@
     <Setting Name="SortDirection" Type="System.String" Scope="User">
       <Value Profile="(Default)">Ascending</Value>
     </Setting>
+    <Setting Name="SettingsUpgradeRequired" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/release-notes.md
+++ b/release-notes.md
@@ -4,6 +4,7 @@ n/a
 
 ## Bugs fixed
 * [Issue 1050](https://github.com/openziti/desktop-edge-win/issues/1050) - Restore monitor service settings from Windows.old after a Windows upgrade
+* [Issue 1054](https://github.com/openziti/desktop-edge-win/issues/1054) - Preserve the identity list sort order and default ext-auth providers across upgrades
 
 ## Other changes
 n/a


### PR DESCRIPTION
Every release stamps a new AssemblyVersion, which moves user.config, so user settings (identity sort preferences, default ext-auth provider) started from defaults on every upgrade.
- Carries SortOption, SortDirection, and DefaultProviders forward from the previous version
- Closes #1054