### PR TITLE
promote 2.11.3.1 to latest and stable, 2.11.5.0 to beta

### DIFF
--- a/release-streams/beta-win32crypto.json
+++ b/release-streams/beta-win32crypto.json
@@ -1,12 +1,12 @@
 {
-  "name": "2.11.4.0",
-  "tag_name": "2.11.4.0",
-  "published_at": "2026-09-01T12:00:00Z",
+  "name": "2.11.5.0",
+  "tag_name": "2.11.5.0",
+  "published_at": "2026-09-02T12:00:00Z",
   "installation_critical": false,
   "assets": [
     {
-      "name": "Ziti.Desktop.Edge.Client-2.11.4.0.exe",
-      "browser_download_url": "https://netfoundry.jfrog.io/artifactory/downloads/desktop-edge-win-win32crypto/2.11.4.0/Ziti.Desktop.Edge.Client-2.11.4.0.exe"
+      "name": "Ziti.Desktop.Edge.Client-2.11.5.0.exe",
+      "browser_download_url": "https://netfoundry.jfrog.io/artifactory/downloads/desktop-edge-win-win32crypto/2.11.5.0/Ziti.Desktop.Edge.Client-2.11.5.0.exe"
     }
   ]
 }

--- a/release-streams/beta.json
+++ b/release-streams/beta.json
@@ -1,12 +1,12 @@
 {
-  "name": "2.11.4.0",
-  "tag_name": "2.11.4.0",
-  "published_at": "2026-09-01T12:00:00Z",
+  "name": "2.11.5.0",
+  "tag_name": "2.11.5.0",
+  "published_at": "2026-09-02T12:00:00Z",
   "installation_critical": false,
   "assets": [
     {
-      "name": "Ziti.Desktop.Edge.Client-2.11.4.0.exe",
-      "browser_download_url": "https://github.com/openziti/desktop-edge-win/releases/download/2.11.4.0/Ziti.Desktop.Edge.Client-2.11.4.0.exe"
+      "name": "Ziti.Desktop.Edge.Client-2.11.5.0.exe",
+      "browser_download_url": "https://github.com/openziti/desktop-edge-win/releases/download/2.11.5.0/Ziti.Desktop.Edge.Client-2.11.5.0.exe"
     }
   ]
 }

--- a/release-streams/latest-win32crypto.json
+++ b/release-streams/latest-win32crypto.json
@@ -1,7 +1,7 @@
 {
   "name": "2.11.3.1",
   "tag_name": "2.11.3.1",
-  "published_at": "2026-09-02T12:00:00Z",
+  "published_at": "2026-08-28T12:00:00Z",
   "installation_critical": false,
   "assets": [
     {

--- a/release-streams/latest-win32crypto.json
+++ b/release-streams/latest-win32crypto.json
@@ -1,12 +1,12 @@
 {
-  "name": "2.11.3.0",
-  "tag_name": "2.11.3.0",
-  "published_at": "2026-08-28T12:00:00Z",
+  "name": "2.11.3.1",
+  "tag_name": "2.11.3.1",
+  "published_at": "2026-09-02T12:00:00Z",
   "installation_critical": false,
   "assets": [
     {
-      "name": "Ziti.Desktop.Edge.Client-2.11.3.0.exe",
-      "browser_download_url": "https://netfoundry.jfrog.io/artifactory/downloads/desktop-edge-win-win32crypto/2.11.3.0/Ziti.Desktop.Edge.Client-2.11.3.0.exe"
+      "name": "Ziti.Desktop.Edge.Client-2.11.3.1.exe",
+      "browser_download_url": "https://netfoundry.jfrog.io/artifactory/downloads/desktop-edge-win-win32crypto/2.11.3.1/Ziti.Desktop.Edge.Client-2.11.3.1.exe"
     }
   ]
 }

--- a/release-streams/latest.json
+++ b/release-streams/latest.json
@@ -1,7 +1,7 @@
 {
   "name": "2.11.3.1",
   "tag_name": "2.11.3.1",
-  "published_at": "2026-09-02T12:00:00Z",
+  "published_at": "2026-08-28T12:00:00Z",
   "installation_critical": false,
   "assets": [
     {

--- a/release-streams/latest.json
+++ b/release-streams/latest.json
@@ -1,12 +1,12 @@
 {
-  "name": "2.11.3.0",
-  "tag_name": "2.11.3.0",
-  "published_at": "2026-08-28T12:00:00Z",
+  "name": "2.11.3.1",
+  "tag_name": "2.11.3.1",
+  "published_at": "2026-09-02T12:00:00Z",
   "installation_critical": false,
   "assets": [
     {
-      "name": "Ziti.Desktop.Edge.Client-2.11.3.0.exe",
-      "browser_download_url": "https://github.com/openziti/desktop-edge-win/releases/download/2.11.3.0/Ziti.Desktop.Edge.Client-2.11.3.0.exe"
+      "name": "Ziti.Desktop.Edge.Client-2.11.3.1.exe",
+      "browser_download_url": "https://github.com/openziti/desktop-edge-win/releases/download/2.11.3.1/Ziti.Desktop.Edge.Client-2.11.3.1.exe"
     }
   ]
 }

--- a/release-streams/stable-win32crypto.json
+++ b/release-streams/stable-win32crypto.json
@@ -1,12 +1,12 @@
 {
-  "name": "2.11.3.0",
-  "tag_name": "2.11.3.0",
-  "published_at": "2026-08-31T12:00:00Z",
+  "name": "2.11.3.1",
+  "tag_name": "2.11.3.1",
+  "published_at": "2026-09-02T12:00:00Z",
   "installation_critical": false,
   "assets": [
     {
-      "name": "Ziti.Desktop.Edge.Client-2.11.3.0.exe",
-      "browser_download_url": "https://netfoundry.jfrog.io/artifactory/downloads/desktop-edge-win-win32crypto/2.11.3.0/Ziti.Desktop.Edge.Client-2.11.3.0.exe"
+      "name": "Ziti.Desktop.Edge.Client-2.11.3.1.exe",
+      "browser_download_url": "https://netfoundry.jfrog.io/artifactory/downloads/desktop-edge-win-win32crypto/2.11.3.1/Ziti.Desktop.Edge.Client-2.11.3.1.exe"
     }
   ]
 }

--- a/release-streams/stable-win32crypto.json
+++ b/release-streams/stable-win32crypto.json
@@ -1,7 +1,7 @@
 {
   "name": "2.11.3.1",
   "tag_name": "2.11.3.1",
-  "published_at": "2026-09-02T12:00:00Z",
+  "published_at": "2026-08-31T12:00:00Z",
   "installation_critical": false,
   "assets": [
     {

--- a/release-streams/stable.json
+++ b/release-streams/stable.json
@@ -1,12 +1,12 @@
 {
-  "name": "2.11.3.0",
-  "tag_name": "2.11.3.0",
-  "published_at": "2026-08-31T12:00:00Z",
+  "name": "2.11.3.1",
+  "tag_name": "2.11.3.1",
+  "published_at": "2026-09-02T12:00:00Z",
   "installation_critical": false,
   "assets": [
     {
-      "name": "Ziti.Desktop.Edge.Client-2.11.3.0.exe",
-      "browser_download_url": "https://github.com/openziti/desktop-edge-win/releases/download/2.11.3.0/Ziti.Desktop.Edge.Client-2.11.3.0.exe"
+      "name": "Ziti.Desktop.Edge.Client-2.11.3.1.exe",
+      "browser_download_url": "https://github.com/openziti/desktop-edge-win/releases/download/2.11.3.1/Ziti.Desktop.Edge.Client-2.11.3.1.exe"
     }
   ]
 }

--- a/release-streams/stable.json
+++ b/release-streams/stable.json
@@ -1,7 +1,7 @@
 {
   "name": "2.11.3.1",
   "tag_name": "2.11.3.1",
-  "published_at": "2026-09-02T12:00:00Z",
+  "published_at": "2026-08-31T12:00:00Z",
   "installation_critical": false,
   "assets": [
     {


### PR DESCRIPTION
promote 2.11.3.1 instead of 2.11.3.0 to latest/stable to report the version of zdew properly to the controller using the registry when deployed as a service. else you now will get "ziti-edge-tunnel" and the zet version for the sdk info/appid.

Also promote a new beta build that does the same thing but uses the new sdk version